### PR TITLE
Chore(dependabot.yml): ignoring `@discordjs/voice` and `@discordjs/builders`

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -16,3 +16,5 @@ updates:
       - dependency-name: "node"
       - dependency-name: "discord.js"
       - dependency-name: "discord-api-types"
+      - dependency-name: "@discordjs/voice"
+      - dependency-name: "@discordjs/builders"


### PR DESCRIPTION
Currently unable to keep discord.js up to date due to #112, and so these dependencies that depends on it can't be kept up to date either.