### PR TITLE
Fix: surely detect audio source's end

### DIFF
--- a/src/Component/PlayManager.ts
+++ b/src/Component/PlayManager.ts
@@ -184,7 +184,7 @@ export class PlayManager extends ServerManagerBase {
         connection.play(stream, {
           format: streamType,
           inlineVolume: this.volume !== 100,
-          voiceDataTimeout: 15 * 1000
+          voiceDataTimeout: 30 * 1000
         });
         // setup volume
         this.setVolume(this.volume);
@@ -315,7 +315,6 @@ export class PlayManager extends ServerManagerBase {
           this._currentAudioStream.destroy();
         }
         this._currentAudioStream = null;
-        this._currentAudioInfo = null;
       }
     });
   }
@@ -435,7 +434,7 @@ export class PlayManager extends ServerManagerBase {
     this.Log("onStreamFailed called");
     this._cost = 0;
     this.destroyStream();
-    if(this._errorUrl === this.currentAudioInfo.Url){
+    if(this._errorUrl === this.currentAudioInfo?.Url){
       this._errorCount++;
     }else{
       this._errorCount = 1;

--- a/src/Component/streams/ffmpeg.ts
+++ b/src/Component/streams/ffmpeg.ts
@@ -37,7 +37,7 @@ export function transformThroughFFmpeg(readable:StreamInfo, bitrate:number, effe
   ] : [];
   const outputArgs = output === "ogg" ? [
     "-acodec", "libopus",
-    "-f", "opus",
+    "-f", "webm",
   ] : [
     "-f", "s16le",
   ];


### PR DESCRIPTION
fix #846

## Details
If a Ogg/Opus stream is passed to eris, eris will not detect the end of the stream.
Instead, eris's voice module thinks the audio has been timed out some time after it ended.
At first, I thought the causes of this issue is in the original Ogg/Opus stream.

## Actual Cause
Eris's OggOpusTransformer might have something weird. Due to it, eris's voice module thought the source has not been ended yet even if actually done.

## Workaround
Ogg might be naturally considered to be ok to be passed to eris's voice module as it is however from lots of experiments OggOpusTransformer of eris doesn't detect the end of the stream,
so we decided to pass the stream without conversion only if it is Webm/Opus stream.
In addition to that, Ogg streams will be transformed to Webm through ffmpeg, preventing from going through OggOpusTransformer.

## Effects
Audio expected to degrades a little because unnecessary conversion will be done in some cases

## Future
In the future, the bot will change the core module interacting with discord (see #658 for more info). After that, there expected to be no longer the issue potentially.