### PR TITLE
Update(docs): bump @docusaurus/module-type-aliases from 2.3.1 to 2.4.0 in /docs (#1241) (cherry-picked)

### DIFF
--- a/docs/package-lock.json
+++ b/docs/package-lock.json
@@ -17,7 +17,7 @@
         "react-dom": "^17.0.2"
       },
       "devDependencies": {
-        "@docusaurus/module-type-aliases": "2.3.1",
+        "@docusaurus/module-type-aliases": "2.4.0",
         "@tsconfig/docusaurus": "^1.0.7",
         "pretty-js": "^0.2.2",
         "recursive-copy": "^2.0.14",
@@ -2255,12 +2255,13 @@
       }
     },
     "node_modules/@docusaurus/module-type-aliases": {
-      "version": "2.3.1",
-      "resolved": "https://registry.npmjs.org/@docusaurus/module-type-aliases/-/module-type-aliases-2.3.1.tgz",
-      "integrity": "sha512-6KkxfAVOJqIUynTRb/tphYCl+co3cP0PlHiMDbi+SzmYxMdgIrwYqH9yAnGSDoN6Jk2ZE/JY/Azs/8LPgKP48A==",
+      "version": "2.4.0",
+      "resolved": "https://registry.npmjs.org/@docusaurus/module-type-aliases/-/module-type-aliases-2.4.0.tgz",
+      "integrity": "sha512-YEQO2D3UXs72qCn8Cr+RlycSQXVGN9iEUyuHwTuK4/uL/HFomB2FHSU0vSDM23oLd+X/KibQ3Ez6nGjQLqXcHg==",
+      "dev": true,
       "dependencies": {
         "@docusaurus/react-loadable": "5.5.2",
-        "@docusaurus/types": "2.3.1",
+        "@docusaurus/types": "2.4.0",
         "@types/history": "^4.7.11",
         "@types/react": "*",
         "@types/react-router-config": "*",
@@ -2271,6 +2272,26 @@
       "peerDependencies": {
         "react": "*",
         "react-dom": "*"
+      }
+    },
+    "node_modules/@docusaurus/module-type-aliases/node_modules/@docusaurus/types": {
+      "version": "2.4.0",
+      "resolved": "https://registry.npmjs.org/@docusaurus/types/-/types-2.4.0.tgz",
+      "integrity": "sha512-xaBXr+KIPDkIaef06c+i2HeTqVNixB7yFut5fBXPGI2f1rrmEV2vLMznNGsFwvZ5XmA3Quuefd4OGRkdo97Dhw==",
+      "dev": true,
+      "dependencies": {
+        "@types/history": "^4.7.11",
+        "@types/react": "*",
+        "commander": "^5.1.0",
+        "joi": "^17.6.0",
+        "react-helmet-async": "^1.3.0",
+        "utility-types": "^3.10.0",
+        "webpack": "^5.73.0",
+        "webpack-merge": "^5.8.0"
+      },
+      "peerDependencies": {
+        "react": "^16.8.4 || ^17.0.0",
+        "react-dom": "^16.8.4 || ^17.0.0"
       }
     },
     "node_modules/@docusaurus/plugin-content-blog": {
@@ -2535,6 +2556,25 @@
       },
       "engines": {
         "node": ">=16.14"
+      }
+    },
+    "node_modules/@docusaurus/plugin-content-docs/node_modules/@docusaurus/module-type-aliases": {
+      "version": "2.3.1",
+      "resolved": "https://registry.npmjs.org/@docusaurus/module-type-aliases/-/module-type-aliases-2.3.1.tgz",
+      "integrity": "sha512-6KkxfAVOJqIUynTRb/tphYCl+co3cP0PlHiMDbi+SzmYxMdgIrwYqH9yAnGSDoN6Jk2ZE/JY/Azs/8LPgKP48A==",
+      "dependencies": {
+        "@docusaurus/react-loadable": "5.5.2",
+        "@docusaurus/types": "2.3.1",
+        "@types/history": "^4.7.11",
+        "@types/react": "*",
+        "@types/react-router-config": "*",
+        "@types/react-router-dom": "*",
+        "react-helmet-async": "*",
+        "react-loadable": "npm:@docusaurus/react-loadable@5.5.2"
+      },
+      "peerDependencies": {
+        "react": "*",
+        "react-dom": "*"
       }
     },
     "node_modules/@docusaurus/plugin-content-pages": {
@@ -3550,6 +3590,25 @@
         "node": ">=16.14"
       }
     },
+    "node_modules/@docusaurus/theme-classic/node_modules/@docusaurus/module-type-aliases": {
+      "version": "2.3.1",
+      "resolved": "https://registry.npmjs.org/@docusaurus/module-type-aliases/-/module-type-aliases-2.3.1.tgz",
+      "integrity": "sha512-6KkxfAVOJqIUynTRb/tphYCl+co3cP0PlHiMDbi+SzmYxMdgIrwYqH9yAnGSDoN6Jk2ZE/JY/Azs/8LPgKP48A==",
+      "dependencies": {
+        "@docusaurus/react-loadable": "5.5.2",
+        "@docusaurus/types": "2.3.1",
+        "@types/history": "^4.7.11",
+        "@types/react": "*",
+        "@types/react-router-config": "*",
+        "@types/react-router-dom": "*",
+        "react-helmet-async": "*",
+        "react-loadable": "npm:@docusaurus/react-loadable@5.5.2"
+      },
+      "peerDependencies": {
+        "react": "*",
+        "react-dom": "*"
+      }
+    },
     "node_modules/@docusaurus/theme-common": {
       "version": "2.3.1",
       "resolved": "https://registry.npmjs.org/@docusaurus/theme-common/-/theme-common-2.3.1.tgz",
@@ -3577,6 +3636,25 @@
       "peerDependencies": {
         "react": "^16.8.4 || ^17.0.0",
         "react-dom": "^16.8.4 || ^17.0.0"
+      }
+    },
+    "node_modules/@docusaurus/theme-common/node_modules/@docusaurus/module-type-aliases": {
+      "version": "2.3.1",
+      "resolved": "https://registry.npmjs.org/@docusaurus/module-type-aliases/-/module-type-aliases-2.3.1.tgz",
+      "integrity": "sha512-6KkxfAVOJqIUynTRb/tphYCl+co3cP0PlHiMDbi+SzmYxMdgIrwYqH9yAnGSDoN6Jk2ZE/JY/Azs/8LPgKP48A==",
+      "dependencies": {
+        "@docusaurus/react-loadable": "5.5.2",
+        "@docusaurus/types": "2.3.1",
+        "@types/history": "^4.7.11",
+        "@types/react": "*",
+        "@types/react-router-config": "*",
+        "@types/react-router-dom": "*",
+        "react-helmet-async": "*",
+        "react-loadable": "npm:@docusaurus/react-loadable@5.5.2"
+      },
+      "peerDependencies": {
+        "react": "*",
+        "react-dom": "*"
       }
     },
     "node_modules/@docusaurus/theme-search-algolia": {
@@ -15442,18 +15520,37 @@
       }
     },
     "@docusaurus/module-type-aliases": {
-      "version": "2.3.1",
-      "resolved": "https://registry.npmjs.org/@docusaurus/module-type-aliases/-/module-type-aliases-2.3.1.tgz",
-      "integrity": "sha512-6KkxfAVOJqIUynTRb/tphYCl+co3cP0PlHiMDbi+SzmYxMdgIrwYqH9yAnGSDoN6Jk2ZE/JY/Azs/8LPgKP48A==",
+      "version": "2.4.0",
+      "resolved": "https://registry.npmjs.org/@docusaurus/module-type-aliases/-/module-type-aliases-2.4.0.tgz",
+      "integrity": "sha512-YEQO2D3UXs72qCn8Cr+RlycSQXVGN9iEUyuHwTuK4/uL/HFomB2FHSU0vSDM23oLd+X/KibQ3Ez6nGjQLqXcHg==",
+      "dev": true,
       "requires": {
         "@docusaurus/react-loadable": "5.5.2",
-        "@docusaurus/types": "2.3.1",
+        "@docusaurus/types": "2.4.0",
         "@types/history": "^4.7.11",
         "@types/react": "*",
         "@types/react-router-config": "*",
         "@types/react-router-dom": "*",
         "react-helmet-async": "*",
         "react-loadable": "npm:@docusaurus/react-loadable@5.5.2"
+      },
+      "dependencies": {
+        "@docusaurus/types": {
+          "version": "2.4.0",
+          "resolved": "https://registry.npmjs.org/@docusaurus/types/-/types-2.4.0.tgz",
+          "integrity": "sha512-xaBXr+KIPDkIaef06c+i2HeTqVNixB7yFut5fBXPGI2f1rrmEV2vLMznNGsFwvZ5XmA3Quuefd4OGRkdo97Dhw==",
+          "dev": true,
+          "requires": {
+            "@types/history": "^4.7.11",
+            "@types/react": "*",
+            "commander": "^5.1.0",
+            "joi": "^17.6.0",
+            "react-helmet-async": "^1.3.0",
+            "utility-types": "^3.10.0",
+            "webpack": "^5.73.0",
+            "webpack-merge": "^5.8.0"
+          }
+        }
       }
     },
     "@docusaurus/plugin-content-blog": {
@@ -15680,6 +15777,21 @@
             "postcss": "^8.4.14",
             "postcss-sort-media-queries": "^4.2.1",
             "tslib": "^2.4.0"
+          }
+        },
+        "@docusaurus/module-type-aliases": {
+          "version": "2.3.1",
+          "resolved": "https://registry.npmjs.org/@docusaurus/module-type-aliases/-/module-type-aliases-2.3.1.tgz",
+          "integrity": "sha512-6KkxfAVOJqIUynTRb/tphYCl+co3cP0PlHiMDbi+SzmYxMdgIrwYqH9yAnGSDoN6Jk2ZE/JY/Azs/8LPgKP48A==",
+          "requires": {
+            "@docusaurus/react-loadable": "5.5.2",
+            "@docusaurus/types": "2.3.1",
+            "@types/history": "^4.7.11",
+            "@types/react": "*",
+            "@types/react-router-config": "*",
+            "@types/react-router-dom": "*",
+            "react-helmet-async": "*",
+            "react-loadable": "npm:@docusaurus/react-loadable@5.5.2"
           }
         }
       }
@@ -16547,6 +16659,21 @@
             "postcss-sort-media-queries": "^4.2.1",
             "tslib": "^2.4.0"
           }
+        },
+        "@docusaurus/module-type-aliases": {
+          "version": "2.3.1",
+          "resolved": "https://registry.npmjs.org/@docusaurus/module-type-aliases/-/module-type-aliases-2.3.1.tgz",
+          "integrity": "sha512-6KkxfAVOJqIUynTRb/tphYCl+co3cP0PlHiMDbi+SzmYxMdgIrwYqH9yAnGSDoN6Jk2ZE/JY/Azs/8LPgKP48A==",
+          "requires": {
+            "@docusaurus/react-loadable": "5.5.2",
+            "@docusaurus/types": "2.3.1",
+            "@types/history": "^4.7.11",
+            "@types/react": "*",
+            "@types/react-router-config": "*",
+            "@types/react-router-dom": "*",
+            "react-helmet-async": "*",
+            "react-loadable": "npm:@docusaurus/react-loadable@5.5.2"
+          }
         }
       }
     },
@@ -16570,6 +16697,23 @@
         "tslib": "^2.4.0",
         "use-sync-external-store": "^1.2.0",
         "utility-types": "^3.10.0"
+      },
+      "dependencies": {
+        "@docusaurus/module-type-aliases": {
+          "version": "2.3.1",
+          "resolved": "https://registry.npmjs.org/@docusaurus/module-type-aliases/-/module-type-aliases-2.3.1.tgz",
+          "integrity": "sha512-6KkxfAVOJqIUynTRb/tphYCl+co3cP0PlHiMDbi+SzmYxMdgIrwYqH9yAnGSDoN6Jk2ZE/JY/Azs/8LPgKP48A==",
+          "requires": {
+            "@docusaurus/react-loadable": "5.5.2",
+            "@docusaurus/types": "2.3.1",
+            "@types/history": "^4.7.11",
+            "@types/react": "*",
+            "@types/react-router-config": "*",
+            "@types/react-router-dom": "*",
+            "react-helmet-async": "*",
+            "react-loadable": "npm:@docusaurus/react-loadable@5.5.2"
+          }
+        }
       }
     },
     "@docusaurus/theme-search-algolia": {

--- a/docs/package.json
+++ b/docs/package.json
@@ -24,7 +24,7 @@
     "react-dom": "^17.0.2"
   },
   "devDependencies": {
-    "@docusaurus/module-type-aliases": "2.3.1",
+    "@docusaurus/module-type-aliases": "2.4.0",
     "@tsconfig/docusaurus": "^1.0.7",
     "pretty-js": "^0.2.2",
     "recursive-copy": "^2.0.14",


### PR DESCRIPTION
Update(docs): bump @docusaurus/module-type-aliases in /docs

Bumps [@docusaurus/module-type-aliases](https://github.com/facebook/docusaurus/tree/HEAD/packages/docusaurus-module-type-aliases) from 2.3.1 to 2.4.0.
- [Release notes](https://github.com/facebook/docusaurus/releases)
- [Changelog](https://github.com/facebook/docusaurus/blob/main/CHANGELOG.md)
- [Commits](https://github.com/facebook/docusaurus/commits/v2.4.0/packages/docusaurus-module-type-aliases)

---
updated-dependencies:
- dependency-name: "@docusaurus/module-type-aliases" dependency-type: direct:development update-type: version-update:semver-minor ...