### PR TITLE
Update(docs): bump @docusaurus/preset-classic from 2.3.1 to 2.4.0 in /docs (#1242) (cherry-picked)

### DIFF
--- a/docs/package-lock.json
+++ b/docs/package-lock.json
@@ -9,7 +9,7 @@
       "version": "0.0.0",
       "dependencies": {
         "@docusaurus/core": "2.4.0",
-        "@docusaurus/preset-classic": "2.3.1",
+        "@docusaurus/preset-classic": "2.4.0",
         "@mdx-js/react": "^1.6.22",
         "clsx": "^1.2.1",
         "prism-react-renderer": "^1.3.5",
@@ -53,74 +53,74 @@
       "integrity": "sha512-2VGCk7I9tA9Ge73Km99+Qg87w0wzW4tgUruvWAn/gfey1ZXgmxZtyIRBebk35R1O8TbK77wujVtCnpsGpRy1kg=="
     },
     "node_modules/@algolia/cache-browser-local-storage": {
-      "version": "4.14.3",
-      "resolved": "https://registry.npmjs.org/@algolia/cache-browser-local-storage/-/cache-browser-local-storage-4.14.3.tgz",
-      "integrity": "sha512-hWH1yCxgG3+R/xZIscmUrWAIBnmBFHH5j30fY/+aPkEZWt90wYILfAHIOZ1/Wxhho5SkPfwFmT7ooX2d9JeQBw==",
+      "version": "4.16.0",
+      "resolved": "https://registry.npmjs.org/@algolia/cache-browser-local-storage/-/cache-browser-local-storage-4.16.0.tgz",
+      "integrity": "sha512-jVrk0YB3tjOhD5/lhBtYCVCeLjZmVpf2kdi4puApofytf/R0scjWz0GdozlW4HhU+Prxmt/c9ge4QFjtv5OAzQ==",
       "dependencies": {
-        "@algolia/cache-common": "4.14.3"
+        "@algolia/cache-common": "4.16.0"
       }
     },
     "node_modules/@algolia/cache-common": {
-      "version": "4.14.3",
-      "resolved": "https://registry.npmjs.org/@algolia/cache-common/-/cache-common-4.14.3.tgz",
-      "integrity": "sha512-oZJofOoD9FQOwiGTzyRnmzvh3ZP8WVTNPBLH5xU5JNF7drDbRT0ocVT0h/xB2rPHYzOeXRrLaQQBwRT/CKom0Q=="
+      "version": "4.16.0",
+      "resolved": "https://registry.npmjs.org/@algolia/cache-common/-/cache-common-4.16.0.tgz",
+      "integrity": "sha512-4iHjkSYQYw46pITrNQgXXhvUmcekI8INz1m+SzmqLX8jexSSy4Ky4zfGhZzhhhLHXUP3+x/PK/c0qPjxEvRwKQ=="
     },
     "node_modules/@algolia/cache-in-memory": {
-      "version": "4.14.3",
-      "resolved": "https://registry.npmjs.org/@algolia/cache-in-memory/-/cache-in-memory-4.14.3.tgz",
-      "integrity": "sha512-ES0hHQnzWjeioLQf5Nq+x1AWdZJ50znNPSH3puB/Y4Xsg4Av1bvLmTJe7SY2uqONaeMTvL0OaVcoVtQgJVw0vg==",
+      "version": "4.16.0",
+      "resolved": "https://registry.npmjs.org/@algolia/cache-in-memory/-/cache-in-memory-4.16.0.tgz",
+      "integrity": "sha512-p7RYykvA6Ip6QENxrh99nOD77otVh1sJRivcgcVpnjoZb5sIN3t33eUY1DpB9QSBizcrW+qk19rNkdnZ43a+PQ==",
       "dependencies": {
-        "@algolia/cache-common": "4.14.3"
+        "@algolia/cache-common": "4.16.0"
       }
     },
     "node_modules/@algolia/client-account": {
-      "version": "4.14.3",
-      "resolved": "https://registry.npmjs.org/@algolia/client-account/-/client-account-4.14.3.tgz",
-      "integrity": "sha512-PBcPb0+f5Xbh5UfLZNx2Ow589OdP8WYjB4CnvupfYBrl9JyC1sdH4jcq/ri8osO/mCZYjZrQsKAPIqW/gQmizQ==",
+      "version": "4.16.0",
+      "resolved": "https://registry.npmjs.org/@algolia/client-account/-/client-account-4.16.0.tgz",
+      "integrity": "sha512-eydcfpdIyuWoKgUSz5iZ/L0wE/Wl7958kACkvTHLDNXvK/b8Z1zypoJavh6/km1ZNQmFpeYS2jrmq0kUSFn02w==",
       "dependencies": {
-        "@algolia/client-common": "4.14.3",
-        "@algolia/client-search": "4.14.3",
-        "@algolia/transporter": "4.14.3"
+        "@algolia/client-common": "4.16.0",
+        "@algolia/client-search": "4.16.0",
+        "@algolia/transporter": "4.16.0"
       }
     },
     "node_modules/@algolia/client-analytics": {
-      "version": "4.14.3",
-      "resolved": "https://registry.npmjs.org/@algolia/client-analytics/-/client-analytics-4.14.3.tgz",
-      "integrity": "sha512-eAwQq0Hb/aauv9NhCH5Dp3Nm29oFx28sayFN2fdOWemwSeJHIl7TmcsxVlRsO50fsD8CtPcDhtGeD3AIFLNvqw==",
+      "version": "4.16.0",
+      "resolved": "https://registry.npmjs.org/@algolia/client-analytics/-/client-analytics-4.16.0.tgz",
+      "integrity": "sha512-cONWXH3BfilgdlCofUm492bJRWtpBLVW/hsUlfoFtiX1u05xoBP7qeiDwh9RR+4pSLHLodYkHAf5U4honQ55Qg==",
       "dependencies": {
-        "@algolia/client-common": "4.14.3",
-        "@algolia/client-search": "4.14.3",
-        "@algolia/requester-common": "4.14.3",
-        "@algolia/transporter": "4.14.3"
+        "@algolia/client-common": "4.16.0",
+        "@algolia/client-search": "4.16.0",
+        "@algolia/requester-common": "4.16.0",
+        "@algolia/transporter": "4.16.0"
       }
     },
     "node_modules/@algolia/client-common": {
-      "version": "4.14.3",
-      "resolved": "https://registry.npmjs.org/@algolia/client-common/-/client-common-4.14.3.tgz",
-      "integrity": "sha512-jkPPDZdi63IK64Yg4WccdCsAP4pHxSkr4usplkUZM5C1l1oEpZXsy2c579LQ0rvwCs5JFmwfNG4ahOszidfWPw==",
+      "version": "4.16.0",
+      "resolved": "https://registry.npmjs.org/@algolia/client-common/-/client-common-4.16.0.tgz",
+      "integrity": "sha512-QVdR4019ukBH6f5lFr27W60trRxQF1SfS1qo0IP6gjsKhXhUVJuHxOCA6ArF87jrNkeuHEoRoDU+GlvaecNo8g==",
       "dependencies": {
-        "@algolia/requester-common": "4.14.3",
-        "@algolia/transporter": "4.14.3"
+        "@algolia/requester-common": "4.16.0",
+        "@algolia/transporter": "4.16.0"
       }
     },
     "node_modules/@algolia/client-personalization": {
-      "version": "4.14.3",
-      "resolved": "https://registry.npmjs.org/@algolia/client-personalization/-/client-personalization-4.14.3.tgz",
-      "integrity": "sha512-UCX1MtkVNgaOL9f0e22x6tC9e2H3unZQlSUdnVaSKpZ+hdSChXGaRjp2UIT7pxmPqNCyv51F597KEX5WT60jNg==",
+      "version": "4.16.0",
+      "resolved": "https://registry.npmjs.org/@algolia/client-personalization/-/client-personalization-4.16.0.tgz",
+      "integrity": "sha512-irtLafssDGPuhYqIwxqOxiWlVYvrsBD+EMA1P9VJtkKi3vSNBxiWeQ0f0Tn53cUNdSRNEssfoEH84JL97SV2SQ==",
       "dependencies": {
-        "@algolia/client-common": "4.14.3",
-        "@algolia/requester-common": "4.14.3",
-        "@algolia/transporter": "4.14.3"
+        "@algolia/client-common": "4.16.0",
+        "@algolia/requester-common": "4.16.0",
+        "@algolia/transporter": "4.16.0"
       }
     },
     "node_modules/@algolia/client-search": {
-      "version": "4.14.3",
-      "resolved": "https://registry.npmjs.org/@algolia/client-search/-/client-search-4.14.3.tgz",
-      "integrity": "sha512-I2U7xBx5OPFdPLA8AXKUPPxGY3HDxZ4r7+mlZ8ZpLbI8/ri6fnu6B4z3wcL7sgHhDYMwnAE8Xr0AB0h3Hnkp4A==",
+      "version": "4.16.0",
+      "resolved": "https://registry.npmjs.org/@algolia/client-search/-/client-search-4.16.0.tgz",
+      "integrity": "sha512-xsfrAE1jO/JDh1wFrRz+alVyW+aA6qnkzmbWWWZWEgVF3EaFqzIf9r1l/aDtDdBtNTNhX9H3Lg31+BRtd5izQA==",
       "dependencies": {
-        "@algolia/client-common": "4.14.3",
-        "@algolia/requester-common": "4.14.3",
-        "@algolia/transporter": "4.14.3"
+        "@algolia/client-common": "4.16.0",
+        "@algolia/requester-common": "4.16.0",
+        "@algolia/transporter": "4.16.0"
       }
     },
     "node_modules/@algolia/events": {
@@ -129,47 +129,47 @@
       "integrity": "sha512-FQzvOCgoFXAbf5Y6mYozw2aj5KCJoA3m4heImceldzPSMbdyS4atVjJzXKMsfX3wnZTFYwkkt8/z8UesLHlSBQ=="
     },
     "node_modules/@algolia/logger-common": {
-      "version": "4.14.3",
-      "resolved": "https://registry.npmjs.org/@algolia/logger-common/-/logger-common-4.14.3.tgz",
-      "integrity": "sha512-kUEAZaBt/J3RjYi8MEBT2QEexJR2kAE2mtLmezsmqMQZTV502TkHCxYzTwY2dE7OKcUTxi4OFlMuS4GId9CWPw=="
+      "version": "4.16.0",
+      "resolved": "https://registry.npmjs.org/@algolia/logger-common/-/logger-common-4.16.0.tgz",
+      "integrity": "sha512-U9H8uCzSDuePJmbnjjTX21aPDRU6x74Tdq3dJmdYu2+pISx02UeBJm4kSgc9RW5jcR5j35G9gnjHY9Q3ngWbyQ=="
     },
     "node_modules/@algolia/logger-console": {
-      "version": "4.14.3",
-      "resolved": "https://registry.npmjs.org/@algolia/logger-console/-/logger-console-4.14.3.tgz",
-      "integrity": "sha512-ZWqAlUITktiMN2EiFpQIFCJS10N96A++yrexqC2Z+3hgF/JcKrOxOdT4nSCQoEPvU4Ki9QKbpzbebRDemZt/hw==",
+      "version": "4.16.0",
+      "resolved": "https://registry.npmjs.org/@algolia/logger-console/-/logger-console-4.16.0.tgz",
+      "integrity": "sha512-+qymusiM+lPZKrkf0tDjCQA158eEJO2IU+Nr/sJ9TFyI/xkFPjNPzw/Qbc8Iy/xcOXGlc6eMgmyjtVQqAWq6UA==",
       "dependencies": {
-        "@algolia/logger-common": "4.14.3"
+        "@algolia/logger-common": "4.16.0"
       }
     },
     "node_modules/@algolia/requester-browser-xhr": {
-      "version": "4.14.3",
-      "resolved": "https://registry.npmjs.org/@algolia/requester-browser-xhr/-/requester-browser-xhr-4.14.3.tgz",
-      "integrity": "sha512-AZeg2T08WLUPvDncl2XLX2O67W5wIO8MNaT7z5ii5LgBTuk/rU4CikTjCe2xsUleIZeFl++QrPAi4Bdxws6r/Q==",
+      "version": "4.16.0",
+      "resolved": "https://registry.npmjs.org/@algolia/requester-browser-xhr/-/requester-browser-xhr-4.16.0.tgz",
+      "integrity": "sha512-gK+kvs6LHl/PaOJfDuwjkopNbG1djzFLsVBklGBsSU6h6VjFkxIpo6Qq80IK14p9cplYZfhfaL12va6Q9p3KVQ==",
       "dependencies": {
-        "@algolia/requester-common": "4.14.3"
+        "@algolia/requester-common": "4.16.0"
       }
     },
     "node_modules/@algolia/requester-common": {
-      "version": "4.14.3",
-      "resolved": "https://registry.npmjs.org/@algolia/requester-common/-/requester-common-4.14.3.tgz",
-      "integrity": "sha512-RrRzqNyKFDP7IkTuV3XvYGF9cDPn9h6qEDl595lXva3YUk9YSS8+MGZnnkOMHvjkrSCKfoLeLbm/T4tmoIeclw=="
+      "version": "4.16.0",
+      "resolved": "https://registry.npmjs.org/@algolia/requester-common/-/requester-common-4.16.0.tgz",
+      "integrity": "sha512-3Zmcs/iMubcm4zqZ3vZG6Zum8t+hMWxGMzo0/uY2BD8o9q5vMxIYI0c4ocdgQjkXcix189WtZNkgjSOBzSbkdw=="
     },
     "node_modules/@algolia/requester-node-http": {
-      "version": "4.14.3",
-      "resolved": "https://registry.npmjs.org/@algolia/requester-node-http/-/requester-node-http-4.14.3.tgz",
-      "integrity": "sha512-O5wnPxtDRPuW2U0EaOz9rMMWdlhwP0J0eSL1Z7TtXF8xnUeeUyNJrdhV5uy2CAp6RbhM1VuC3sOJcIR6Av+vbA==",
+      "version": "4.16.0",
+      "resolved": "https://registry.npmjs.org/@algolia/requester-node-http/-/requester-node-http-4.16.0.tgz",
+      "integrity": "sha512-L8JxM2VwZzh8LJ1Zb8TFS6G3icYsCKZsdWW+ahcEs1rGWmyk9SybsOe1MLnjonGBaqPWJkn9NjS7mRdjEmBtKA==",
       "dependencies": {
-        "@algolia/requester-common": "4.14.3"
+        "@algolia/requester-common": "4.16.0"
       }
     },
     "node_modules/@algolia/transporter": {
-      "version": "4.14.3",
-      "resolved": "https://registry.npmjs.org/@algolia/transporter/-/transporter-4.14.3.tgz",
-      "integrity": "sha512-2qlKlKsnGJ008exFRb5RTeTOqhLZj0bkMCMVskxoqWejs2Q2QtWmsiH98hDfpw0fmnyhzHEt0Z7lqxBYp8bW2w==",
+      "version": "4.16.0",
+      "resolved": "https://registry.npmjs.org/@algolia/transporter/-/transporter-4.16.0.tgz",
+      "integrity": "sha512-H9BVB2EAjT65w7XGBNf5drpsW39x2aSZ942j4boSAAJPPlLmjtj5IpAP7UAtsV8g9Beslonh0bLa1XGmE/P0BA==",
       "dependencies": {
-        "@algolia/cache-common": "4.14.3",
-        "@algolia/logger-common": "4.14.3",
-        "@algolia/requester-common": "4.14.3"
+        "@algolia/cache-common": "4.16.0",
+        "@algolia/logger-common": "4.16.0",
+        "@algolia/requester-common": "4.16.0"
       }
     },
     "node_modules/@ampproject/remapping": {
@@ -1889,11 +1889,11 @@
       }
     },
     "node_modules/@babel/runtime": {
-      "version": "7.19.0",
-      "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.19.0.tgz",
-      "integrity": "sha512-eR8Lo9hnDS7tqkO7NsV+mKvCmv5boaXFSZ70DnfhcgiEne8hv9oCEd36Klw74EtizEqLsy4YnW8UWwpBVolHZA==",
+      "version": "7.21.0",
+      "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.21.0.tgz",
+      "integrity": "sha512-xwII0//EObnq89Ji5AKYQaRYiW/nZ3llSv29d49IuxPhKbtJoLP+9QUUZ4nVragQVtaVGeZrpB+ZtG/Pdy/POw==",
       "dependencies": {
-        "regenerator-runtime": "^0.13.4"
+        "regenerator-runtime": "^0.13.11"
       },
       "engines": {
         "node": ">=6.9.0"
@@ -1967,18 +1967,18 @@
       }
     },
     "node_modules/@docsearch/css": {
-      "version": "3.3.2",
-      "resolved": "https://registry.npmjs.org/@docsearch/css/-/css-3.3.2.tgz",
-      "integrity": "sha512-dctFYiwbvDZkksMlsmc7pj6W6By/EjnVXJq5TEPd05MwQe+dcdHJgaIn1c8wfsucxHpIsdrUcgSkACHCq6aIhw=="
+      "version": "3.3.3",
+      "resolved": "https://registry.npmjs.org/@docsearch/css/-/css-3.3.3.tgz",
+      "integrity": "sha512-6SCwI7P8ao+se1TUsdZ7B4XzL+gqeQZnBc+2EONZlcVa0dVrk0NjETxozFKgMv0eEGH8QzP1fkN+A1rH61l4eg=="
     },
     "node_modules/@docsearch/react": {
-      "version": "3.3.2",
-      "resolved": "https://registry.npmjs.org/@docsearch/react/-/react-3.3.2.tgz",
-      "integrity": "sha512-ugILab2TYKSh6IEHf6Z9xZbOovsYbsdfo60PBj+Bw+oMJ1MHJ7pBt1TTcmPki1hSgg8mysgKy2hDiVdPm7XWSQ==",
+      "version": "3.3.3",
+      "resolved": "https://registry.npmjs.org/@docsearch/react/-/react-3.3.3.tgz",
+      "integrity": "sha512-pLa0cxnl+G0FuIDuYlW+EBK6Rw2jwLw9B1RHIeS4N4s2VhsfJ/wzeCi3CWcs5yVfxLd5ZK50t//TMA5e79YT7Q==",
       "dependencies": {
         "@algolia/autocomplete-core": "1.7.4",
         "@algolia/autocomplete-preset-algolia": "1.7.4",
-        "@docsearch/css": "3.3.2",
+        "@docsearch/css": "3.3.3",
         "algoliasearch": "^4.0.0"
       },
       "peerDependencies": {
@@ -2086,7 +2086,21 @@
         "react-dom": "^16.8.4 || ^17.0.0"
       }
     },
-    "node_modules/@docusaurus/core/node_modules/@docusaurus/logger": {
+    "node_modules/@docusaurus/cssnano-preset": {
+      "version": "2.4.0",
+      "resolved": "https://registry.npmjs.org/@docusaurus/cssnano-preset/-/cssnano-preset-2.4.0.tgz",
+      "integrity": "sha512-RmdiA3IpsLgZGXRzqnmTbGv43W4OD44PCo+6Q/aYjEM2V57vKCVqNzuafE94jv0z/PjHoXUrjr69SaRymBKYYw==",
+      "dependencies": {
+        "cssnano-preset-advanced": "^5.3.8",
+        "postcss": "^8.4.14",
+        "postcss-sort-media-queries": "^4.2.1",
+        "tslib": "^2.4.0"
+      },
+      "engines": {
+        "node": ">=16.14"
+      }
+    },
+    "node_modules/@docusaurus/logger": {
       "version": "2.4.0",
       "resolved": "https://registry.npmjs.org/@docusaurus/logger/-/logger-2.4.0.tgz",
       "integrity": "sha512-T8+qR4APN+MjcC9yL2Es+xPJ2923S9hpzDmMtdsOcUGLqpCGBbU1vp3AAqDwXtVgFkq+NsEk7sHdVsfLWR/AXw==",
@@ -2098,7 +2112,7 @@
         "node": ">=16.14"
       }
     },
-    "node_modules/@docusaurus/core/node_modules/@docusaurus/mdx-loader": {
+    "node_modules/@docusaurus/mdx-loader": {
       "version": "2.4.0",
       "resolved": "https://registry.npmjs.org/@docusaurus/mdx-loader/-/mdx-loader-2.4.0.tgz",
       "integrity": "sha512-GWoH4izZKOmFoC+gbI2/y8deH/xKLvzz/T5BsEexBye8EHQlwsA7FMrVa48N063bJBH4FUOiRRXxk5rq9cC36g==",
@@ -2129,7 +2143,374 @@
         "react-dom": "^16.8.4 || ^17.0.0"
       }
     },
-    "node_modules/@docusaurus/core/node_modules/@docusaurus/utils": {
+    "node_modules/@docusaurus/module-type-aliases": {
+      "version": "2.4.0",
+      "resolved": "https://registry.npmjs.org/@docusaurus/module-type-aliases/-/module-type-aliases-2.4.0.tgz",
+      "integrity": "sha512-YEQO2D3UXs72qCn8Cr+RlycSQXVGN9iEUyuHwTuK4/uL/HFomB2FHSU0vSDM23oLd+X/KibQ3Ez6nGjQLqXcHg==",
+      "dependencies": {
+        "@docusaurus/react-loadable": "5.5.2",
+        "@docusaurus/types": "2.4.0",
+        "@types/history": "^4.7.11",
+        "@types/react": "*",
+        "@types/react-router-config": "*",
+        "@types/react-router-dom": "*",
+        "react-helmet-async": "*",
+        "react-loadable": "npm:@docusaurus/react-loadable@5.5.2"
+      },
+      "peerDependencies": {
+        "react": "*",
+        "react-dom": "*"
+      }
+    },
+    "node_modules/@docusaurus/plugin-content-blog": {
+      "version": "2.4.0",
+      "resolved": "https://registry.npmjs.org/@docusaurus/plugin-content-blog/-/plugin-content-blog-2.4.0.tgz",
+      "integrity": "sha512-YwkAkVUxtxoBAIj/MCb4ohN0SCtHBs4AS75jMhPpf67qf3j+U/4n33cELq7567hwyZ6fMz2GPJcVmctzlGGThQ==",
+      "dependencies": {
+        "@docusaurus/core": "2.4.0",
+        "@docusaurus/logger": "2.4.0",
+        "@docusaurus/mdx-loader": "2.4.0",
+        "@docusaurus/types": "2.4.0",
+        "@docusaurus/utils": "2.4.0",
+        "@docusaurus/utils-common": "2.4.0",
+        "@docusaurus/utils-validation": "2.4.0",
+        "cheerio": "^1.0.0-rc.12",
+        "feed": "^4.2.2",
+        "fs-extra": "^10.1.0",
+        "lodash": "^4.17.21",
+        "reading-time": "^1.5.0",
+        "tslib": "^2.4.0",
+        "unist-util-visit": "^2.0.3",
+        "utility-types": "^3.10.0",
+        "webpack": "^5.73.0"
+      },
+      "engines": {
+        "node": ">=16.14"
+      },
+      "peerDependencies": {
+        "react": "^16.8.4 || ^17.0.0",
+        "react-dom": "^16.8.4 || ^17.0.0"
+      }
+    },
+    "node_modules/@docusaurus/plugin-content-docs": {
+      "version": "2.4.0",
+      "resolved": "https://registry.npmjs.org/@docusaurus/plugin-content-docs/-/plugin-content-docs-2.4.0.tgz",
+      "integrity": "sha512-ic/Z/ZN5Rk/RQo+Io6rUGpToOtNbtPloMR2JcGwC1xT2riMu6zzfSwmBi9tHJgdXH6CB5jG+0dOZZO8QS5tmDg==",
+      "dependencies": {
+        "@docusaurus/core": "2.4.0",
+        "@docusaurus/logger": "2.4.0",
+        "@docusaurus/mdx-loader": "2.4.0",
+        "@docusaurus/module-type-aliases": "2.4.0",
+        "@docusaurus/types": "2.4.0",
+        "@docusaurus/utils": "2.4.0",
+        "@docusaurus/utils-validation": "2.4.0",
+        "@types/react-router-config": "^5.0.6",
+        "combine-promises": "^1.1.0",
+        "fs-extra": "^10.1.0",
+        "import-fresh": "^3.3.0",
+        "js-yaml": "^4.1.0",
+        "lodash": "^4.17.21",
+        "tslib": "^2.4.0",
+        "utility-types": "^3.10.0",
+        "webpack": "^5.73.0"
+      },
+      "engines": {
+        "node": ">=16.14"
+      },
+      "peerDependencies": {
+        "react": "^16.8.4 || ^17.0.0",
+        "react-dom": "^16.8.4 || ^17.0.0"
+      }
+    },
+    "node_modules/@docusaurus/plugin-content-pages": {
+      "version": "2.4.0",
+      "resolved": "https://registry.npmjs.org/@docusaurus/plugin-content-pages/-/plugin-content-pages-2.4.0.tgz",
+      "integrity": "sha512-Pk2pOeOxk8MeU3mrTU0XLIgP9NZixbdcJmJ7RUFrZp1Aj42nd0RhIT14BGvXXyqb8yTQlk4DmYGAzqOfBsFyGw==",
+      "dependencies": {
+        "@docusaurus/core": "2.4.0",
+        "@docusaurus/mdx-loader": "2.4.0",
+        "@docusaurus/types": "2.4.0",
+        "@docusaurus/utils": "2.4.0",
+        "@docusaurus/utils-validation": "2.4.0",
+        "fs-extra": "^10.1.0",
+        "tslib": "^2.4.0",
+        "webpack": "^5.73.0"
+      },
+      "engines": {
+        "node": ">=16.14"
+      },
+      "peerDependencies": {
+        "react": "^16.8.4 || ^17.0.0",
+        "react-dom": "^16.8.4 || ^17.0.0"
+      }
+    },
+    "node_modules/@docusaurus/plugin-debug": {
+      "version": "2.4.0",
+      "resolved": "https://registry.npmjs.org/@docusaurus/plugin-debug/-/plugin-debug-2.4.0.tgz",
+      "integrity": "sha512-KC56DdYjYT7Txyux71vXHXGYZuP6yYtqwClvYpjKreWIHWus5Zt6VNi23rMZv3/QKhOCrN64zplUbdfQMvddBQ==",
+      "dependencies": {
+        "@docusaurus/core": "2.4.0",
+        "@docusaurus/types": "2.4.0",
+        "@docusaurus/utils": "2.4.0",
+        "fs-extra": "^10.1.0",
+        "react-json-view": "^1.21.3",
+        "tslib": "^2.4.0"
+      },
+      "engines": {
+        "node": ">=16.14"
+      },
+      "peerDependencies": {
+        "react": "^16.8.4 || ^17.0.0",
+        "react-dom": "^16.8.4 || ^17.0.0"
+      }
+    },
+    "node_modules/@docusaurus/plugin-google-analytics": {
+      "version": "2.4.0",
+      "resolved": "https://registry.npmjs.org/@docusaurus/plugin-google-analytics/-/plugin-google-analytics-2.4.0.tgz",
+      "integrity": "sha512-uGUzX67DOAIglygdNrmMOvEp8qG03X20jMWadeqVQktS6nADvozpSLGx4J0xbkblhJkUzN21WiilsP9iVP+zkw==",
+      "dependencies": {
+        "@docusaurus/core": "2.4.0",
+        "@docusaurus/types": "2.4.0",
+        "@docusaurus/utils-validation": "2.4.0",
+        "tslib": "^2.4.0"
+      },
+      "engines": {
+        "node": ">=16.14"
+      },
+      "peerDependencies": {
+        "react": "^16.8.4 || ^17.0.0",
+        "react-dom": "^16.8.4 || ^17.0.0"
+      }
+    },
+    "node_modules/@docusaurus/plugin-google-gtag": {
+      "version": "2.4.0",
+      "resolved": "https://registry.npmjs.org/@docusaurus/plugin-google-gtag/-/plugin-google-gtag-2.4.0.tgz",
+      "integrity": "sha512-adj/70DANaQs2+TF/nRdMezDXFAV/O/pjAbUgmKBlyOTq5qoMe0Tk4muvQIwWUmiUQxFJe+sKlZGM771ownyOg==",
+      "dependencies": {
+        "@docusaurus/core": "2.4.0",
+        "@docusaurus/types": "2.4.0",
+        "@docusaurus/utils-validation": "2.4.0",
+        "tslib": "^2.4.0"
+      },
+      "engines": {
+        "node": ">=16.14"
+      },
+      "peerDependencies": {
+        "react": "^16.8.4 || ^17.0.0",
+        "react-dom": "^16.8.4 || ^17.0.0"
+      }
+    },
+    "node_modules/@docusaurus/plugin-google-tag-manager": {
+      "version": "2.4.0",
+      "resolved": "https://registry.npmjs.org/@docusaurus/plugin-google-tag-manager/-/plugin-google-tag-manager-2.4.0.tgz",
+      "integrity": "sha512-E66uGcYs4l7yitmp/8kMEVQftFPwV9iC62ORh47Veqzs6ExwnhzBkJmwDnwIysHBF1vlxnzET0Fl2LfL5fRR3A==",
+      "dependencies": {
+        "@docusaurus/core": "2.4.0",
+        "@docusaurus/types": "2.4.0",
+        "@docusaurus/utils-validation": "2.4.0",
+        "tslib": "^2.4.0"
+      },
+      "engines": {
+        "node": ">=16.14"
+      },
+      "peerDependencies": {
+        "react": "^16.8.4 || ^17.0.0",
+        "react-dom": "^16.8.4 || ^17.0.0"
+      }
+    },
+    "node_modules/@docusaurus/plugin-sitemap": {
+      "version": "2.4.0",
+      "resolved": "https://registry.npmjs.org/@docusaurus/plugin-sitemap/-/plugin-sitemap-2.4.0.tgz",
+      "integrity": "sha512-pZxh+ygfnI657sN8a/FkYVIAmVv0CGk71QMKqJBOfMmDHNN1FeDeFkBjWP49ejBqpqAhjufkv5UWq3UOu2soCw==",
+      "dependencies": {
+        "@docusaurus/core": "2.4.0",
+        "@docusaurus/logger": "2.4.0",
+        "@docusaurus/types": "2.4.0",
+        "@docusaurus/utils": "2.4.0",
+        "@docusaurus/utils-common": "2.4.0",
+        "@docusaurus/utils-validation": "2.4.0",
+        "fs-extra": "^10.1.0",
+        "sitemap": "^7.1.1",
+        "tslib": "^2.4.0"
+      },
+      "engines": {
+        "node": ">=16.14"
+      },
+      "peerDependencies": {
+        "react": "^16.8.4 || ^17.0.0",
+        "react-dom": "^16.8.4 || ^17.0.0"
+      }
+    },
+    "node_modules/@docusaurus/preset-classic": {
+      "version": "2.4.0",
+      "resolved": "https://registry.npmjs.org/@docusaurus/preset-classic/-/preset-classic-2.4.0.tgz",
+      "integrity": "sha512-/5z5o/9bc6+P5ool2y01PbJhoGddEGsC0ej1MF6mCoazk8A+kW4feoUd68l7Bnv01rCnG3xy7kHUQP97Y0grUA==",
+      "dependencies": {
+        "@docusaurus/core": "2.4.0",
+        "@docusaurus/plugin-content-blog": "2.4.0",
+        "@docusaurus/plugin-content-docs": "2.4.0",
+        "@docusaurus/plugin-content-pages": "2.4.0",
+        "@docusaurus/plugin-debug": "2.4.0",
+        "@docusaurus/plugin-google-analytics": "2.4.0",
+        "@docusaurus/plugin-google-gtag": "2.4.0",
+        "@docusaurus/plugin-google-tag-manager": "2.4.0",
+        "@docusaurus/plugin-sitemap": "2.4.0",
+        "@docusaurus/theme-classic": "2.4.0",
+        "@docusaurus/theme-common": "2.4.0",
+        "@docusaurus/theme-search-algolia": "2.4.0",
+        "@docusaurus/types": "2.4.0"
+      },
+      "engines": {
+        "node": ">=16.14"
+      },
+      "peerDependencies": {
+        "react": "^16.8.4 || ^17.0.0",
+        "react-dom": "^16.8.4 || ^17.0.0"
+      }
+    },
+    "node_modules/@docusaurus/react-loadable": {
+      "version": "5.5.2",
+      "resolved": "https://registry.npmjs.org/@docusaurus/react-loadable/-/react-loadable-5.5.2.tgz",
+      "integrity": "sha512-A3dYjdBGuy0IGT+wyLIGIKLRE+sAk1iNk0f1HjNDysO7u8lhL4N3VEm+FAubmJbAztn94F7MxBTPmnixbiyFdQ==",
+      "dependencies": {
+        "@types/react": "*",
+        "prop-types": "^15.6.2"
+      },
+      "peerDependencies": {
+        "react": "*"
+      }
+    },
+    "node_modules/@docusaurus/theme-classic": {
+      "version": "2.4.0",
+      "resolved": "https://registry.npmjs.org/@docusaurus/theme-classic/-/theme-classic-2.4.0.tgz",
+      "integrity": "sha512-GMDX5WU6Z0OC65eQFgl3iNNEbI9IMJz9f6KnOyuMxNUR6q0qVLsKCNopFUDfFNJ55UU50o7P7o21yVhkwpfJ9w==",
+      "dependencies": {
+        "@docusaurus/core": "2.4.0",
+        "@docusaurus/mdx-loader": "2.4.0",
+        "@docusaurus/module-type-aliases": "2.4.0",
+        "@docusaurus/plugin-content-blog": "2.4.0",
+        "@docusaurus/plugin-content-docs": "2.4.0",
+        "@docusaurus/plugin-content-pages": "2.4.0",
+        "@docusaurus/theme-common": "2.4.0",
+        "@docusaurus/theme-translations": "2.4.0",
+        "@docusaurus/types": "2.4.0",
+        "@docusaurus/utils": "2.4.0",
+        "@docusaurus/utils-common": "2.4.0",
+        "@docusaurus/utils-validation": "2.4.0",
+        "@mdx-js/react": "^1.6.22",
+        "clsx": "^1.2.1",
+        "copy-text-to-clipboard": "^3.0.1",
+        "infima": "0.2.0-alpha.43",
+        "lodash": "^4.17.21",
+        "nprogress": "^0.2.0",
+        "postcss": "^8.4.14",
+        "prism-react-renderer": "^1.3.5",
+        "prismjs": "^1.28.0",
+        "react-router-dom": "^5.3.3",
+        "rtlcss": "^3.5.0",
+        "tslib": "^2.4.0",
+        "utility-types": "^3.10.0"
+      },
+      "engines": {
+        "node": ">=16.14"
+      },
+      "peerDependencies": {
+        "react": "^16.8.4 || ^17.0.0",
+        "react-dom": "^16.8.4 || ^17.0.0"
+      }
+    },
+    "node_modules/@docusaurus/theme-common": {
+      "version": "2.4.0",
+      "resolved": "https://registry.npmjs.org/@docusaurus/theme-common/-/theme-common-2.4.0.tgz",
+      "integrity": "sha512-IkG/l5f/FLY6cBIxtPmFnxpuPzc5TupuqlOx+XDN+035MdQcAh8wHXXZJAkTeYDeZ3anIUSUIvWa7/nRKoQEfg==",
+      "dependencies": {
+        "@docusaurus/mdx-loader": "2.4.0",
+        "@docusaurus/module-type-aliases": "2.4.0",
+        "@docusaurus/plugin-content-blog": "2.4.0",
+        "@docusaurus/plugin-content-docs": "2.4.0",
+        "@docusaurus/plugin-content-pages": "2.4.0",
+        "@docusaurus/utils": "2.4.0",
+        "@docusaurus/utils-common": "2.4.0",
+        "@types/history": "^4.7.11",
+        "@types/react": "*",
+        "@types/react-router-config": "*",
+        "clsx": "^1.2.1",
+        "parse-numeric-range": "^1.3.0",
+        "prism-react-renderer": "^1.3.5",
+        "tslib": "^2.4.0",
+        "use-sync-external-store": "^1.2.0",
+        "utility-types": "^3.10.0"
+      },
+      "engines": {
+        "node": ">=16.14"
+      },
+      "peerDependencies": {
+        "react": "^16.8.4 || ^17.0.0",
+        "react-dom": "^16.8.4 || ^17.0.0"
+      }
+    },
+    "node_modules/@docusaurus/theme-search-algolia": {
+      "version": "2.4.0",
+      "resolved": "https://registry.npmjs.org/@docusaurus/theme-search-algolia/-/theme-search-algolia-2.4.0.tgz",
+      "integrity": "sha512-pPCJSCL1Qt4pu/Z0uxBAuke0yEBbxh0s4fOvimna7TEcBLPq0x06/K78AaABXrTVQM6S0vdocFl9EoNgU17hqA==",
+      "dependencies": {
+        "@docsearch/react": "^3.1.1",
+        "@docusaurus/core": "2.4.0",
+        "@docusaurus/logger": "2.4.0",
+        "@docusaurus/plugin-content-docs": "2.4.0",
+        "@docusaurus/theme-common": "2.4.0",
+        "@docusaurus/theme-translations": "2.4.0",
+        "@docusaurus/utils": "2.4.0",
+        "@docusaurus/utils-validation": "2.4.0",
+        "algoliasearch": "^4.13.1",
+        "algoliasearch-helper": "^3.10.0",
+        "clsx": "^1.2.1",
+        "eta": "^2.0.0",
+        "fs-extra": "^10.1.0",
+        "lodash": "^4.17.21",
+        "tslib": "^2.4.0",
+        "utility-types": "^3.10.0"
+      },
+      "engines": {
+        "node": ">=16.14"
+      },
+      "peerDependencies": {
+        "react": "^16.8.4 || ^17.0.0",
+        "react-dom": "^16.8.4 || ^17.0.0"
+      }
+    },
+    "node_modules/@docusaurus/theme-translations": {
+      "version": "2.4.0",
+      "resolved": "https://registry.npmjs.org/@docusaurus/theme-translations/-/theme-translations-2.4.0.tgz",
+      "integrity": "sha512-kEoITnPXzDPUMBHk3+fzEzbopxLD3fR5sDoayNH0vXkpUukA88/aDL1bqkhxWZHA3LOfJ3f0vJbOwmnXW5v85Q==",
+      "dependencies": {
+        "fs-extra": "^10.1.0",
+        "tslib": "^2.4.0"
+      },
+      "engines": {
+        "node": ">=16.14"
+      }
+    },
+    "node_modules/@docusaurus/types": {
+      "version": "2.4.0",
+      "resolved": "https://registry.npmjs.org/@docusaurus/types/-/types-2.4.0.tgz",
+      "integrity": "sha512-xaBXr+KIPDkIaef06c+i2HeTqVNixB7yFut5fBXPGI2f1rrmEV2vLMznNGsFwvZ5XmA3Quuefd4OGRkdo97Dhw==",
+      "dependencies": {
+        "@types/history": "^4.7.11",
+        "@types/react": "*",
+        "commander": "^5.1.0",
+        "joi": "^17.6.0",
+        "react-helmet-async": "^1.3.0",
+        "utility-types": "^3.10.0",
+        "webpack": "^5.73.0",
+        "webpack-merge": "^5.8.0"
+      },
+      "peerDependencies": {
+        "react": "^16.8.4 || ^17.0.0",
+        "react-dom": "^16.8.4 || ^17.0.0"
+      }
+    },
+    "node_modules/@docusaurus/utils": {
       "version": "2.4.0",
       "resolved": "https://registry.npmjs.org/@docusaurus/utils/-/utils-2.4.0.tgz",
       "integrity": "sha512-89hLYkvtRX92j+C+ERYTuSUK6nF9bGM32QThcHPg2EDDHVw6FzYQXmX6/p+pU5SDyyx5nBlE4qXR92RxCAOqfg==",
@@ -2163,7 +2544,7 @@
         }
       }
     },
-    "node_modules/@docusaurus/core/node_modules/@docusaurus/utils-common": {
+    "node_modules/@docusaurus/utils-common": {
       "version": "2.4.0",
       "resolved": "https://registry.npmjs.org/@docusaurus/utils-common/-/utils-common-2.4.0.tgz",
       "integrity": "sha512-zIMf10xuKxddYfLg5cS19x44zud/E9I7lj3+0bv8UIs0aahpErfNrGhijEfJpAfikhQ8tL3m35nH3hJ3sOG82A==",
@@ -2182,1704 +2563,13 @@
         }
       }
     },
-    "node_modules/@docusaurus/core/node_modules/@docusaurus/utils-validation": {
+    "node_modules/@docusaurus/utils-validation": {
       "version": "2.4.0",
       "resolved": "https://registry.npmjs.org/@docusaurus/utils-validation/-/utils-validation-2.4.0.tgz",
       "integrity": "sha512-IrBsBbbAp6y7mZdJx4S4pIA7dUyWSA0GNosPk6ZJ0fX3uYIEQgcQSGIgTeSC+8xPEx3c16o03en1jSDpgQgz/w==",
       "dependencies": {
         "@docusaurus/logger": "2.4.0",
         "@docusaurus/utils": "2.4.0",
-        "joi": "^17.6.0",
-        "js-yaml": "^4.1.0",
-        "tslib": "^2.4.0"
-      },
-      "engines": {
-        "node": ">=16.14"
-      }
-    },
-    "node_modules/@docusaurus/cssnano-preset": {
-      "version": "2.4.0",
-      "resolved": "https://registry.npmjs.org/@docusaurus/cssnano-preset/-/cssnano-preset-2.4.0.tgz",
-      "integrity": "sha512-RmdiA3IpsLgZGXRzqnmTbGv43W4OD44PCo+6Q/aYjEM2V57vKCVqNzuafE94jv0z/PjHoXUrjr69SaRymBKYYw==",
-      "dependencies": {
-        "cssnano-preset-advanced": "^5.3.8",
-        "postcss": "^8.4.14",
-        "postcss-sort-media-queries": "^4.2.1",
-        "tslib": "^2.4.0"
-      },
-      "engines": {
-        "node": ">=16.14"
-      }
-    },
-    "node_modules/@docusaurus/logger": {
-      "version": "2.3.1",
-      "resolved": "https://registry.npmjs.org/@docusaurus/logger/-/logger-2.3.1.tgz",
-      "integrity": "sha512-2lAV/olKKVr9qJhfHFCaqBIl8FgYjbUFwgUnX76+cULwQYss+42ZQ3grHGFvI0ocN2X55WcYe64ellQXz7suqg==",
-      "dependencies": {
-        "chalk": "^4.1.2",
-        "tslib": "^2.4.0"
-      },
-      "engines": {
-        "node": ">=16.14"
-      }
-    },
-    "node_modules/@docusaurus/mdx-loader": {
-      "version": "2.3.1",
-      "resolved": "https://registry.npmjs.org/@docusaurus/mdx-loader/-/mdx-loader-2.3.1.tgz",
-      "integrity": "sha512-Gzga7OsxQRpt3392K9lv/bW4jGppdLFJh3luKRknCKSAaZrmVkOQv2gvCn8LAOSZ3uRg5No7AgYs/vpL8K94lA==",
-      "dependencies": {
-        "@babel/parser": "^7.18.8",
-        "@babel/traverse": "^7.18.8",
-        "@docusaurus/logger": "2.3.1",
-        "@docusaurus/utils": "2.3.1",
-        "@mdx-js/mdx": "^1.6.22",
-        "escape-html": "^1.0.3",
-        "file-loader": "^6.2.0",
-        "fs-extra": "^10.1.0",
-        "image-size": "^1.0.1",
-        "mdast-util-to-string": "^2.0.0",
-        "remark-emoji": "^2.2.0",
-        "stringify-object": "^3.3.0",
-        "tslib": "^2.4.0",
-        "unified": "^9.2.2",
-        "unist-util-visit": "^2.0.3",
-        "url-loader": "^4.1.1",
-        "webpack": "^5.73.0"
-      },
-      "engines": {
-        "node": ">=16.14"
-      },
-      "peerDependencies": {
-        "react": "^16.8.4 || ^17.0.0",
-        "react-dom": "^16.8.4 || ^17.0.0"
-      }
-    },
-    "node_modules/@docusaurus/module-type-aliases": {
-      "version": "2.4.0",
-      "resolved": "https://registry.npmjs.org/@docusaurus/module-type-aliases/-/module-type-aliases-2.4.0.tgz",
-      "integrity": "sha512-YEQO2D3UXs72qCn8Cr+RlycSQXVGN9iEUyuHwTuK4/uL/HFomB2FHSU0vSDM23oLd+X/KibQ3Ez6nGjQLqXcHg==",
-      "dev": true,
-      "dependencies": {
-        "@docusaurus/react-loadable": "5.5.2",
-        "@docusaurus/types": "2.4.0",
-        "@types/history": "^4.7.11",
-        "@types/react": "*",
-        "@types/react-router-config": "*",
-        "@types/react-router-dom": "*",
-        "react-helmet-async": "*",
-        "react-loadable": "npm:@docusaurus/react-loadable@5.5.2"
-      },
-      "peerDependencies": {
-        "react": "*",
-        "react-dom": "*"
-      }
-    },
-    "node_modules/@docusaurus/module-type-aliases/node_modules/@docusaurus/types": {
-      "version": "2.4.0",
-      "resolved": "https://registry.npmjs.org/@docusaurus/types/-/types-2.4.0.tgz",
-      "integrity": "sha512-xaBXr+KIPDkIaef06c+i2HeTqVNixB7yFut5fBXPGI2f1rrmEV2vLMznNGsFwvZ5XmA3Quuefd4OGRkdo97Dhw==",
-      "dev": true,
-      "dependencies": {
-        "@types/history": "^4.7.11",
-        "@types/react": "*",
-        "commander": "^5.1.0",
-        "joi": "^17.6.0",
-        "react-helmet-async": "^1.3.0",
-        "utility-types": "^3.10.0",
-        "webpack": "^5.73.0",
-        "webpack-merge": "^5.8.0"
-      },
-      "peerDependencies": {
-        "react": "^16.8.4 || ^17.0.0",
-        "react-dom": "^16.8.4 || ^17.0.0"
-      }
-    },
-    "node_modules/@docusaurus/plugin-content-blog": {
-      "version": "2.3.1",
-      "resolved": "https://registry.npmjs.org/@docusaurus/plugin-content-blog/-/plugin-content-blog-2.3.1.tgz",
-      "integrity": "sha512-f5LjqX+9WkiLyGiQ41x/KGSJ/9bOjSD8lsVhPvYeUYHCtYpuiDKfhZE07O4EqpHkBx4NQdtQDbp+aptgHSTuiw==",
-      "dependencies": {
-        "@docusaurus/core": "2.3.1",
-        "@docusaurus/logger": "2.3.1",
-        "@docusaurus/mdx-loader": "2.3.1",
-        "@docusaurus/types": "2.3.1",
-        "@docusaurus/utils": "2.3.1",
-        "@docusaurus/utils-common": "2.3.1",
-        "@docusaurus/utils-validation": "2.3.1",
-        "cheerio": "^1.0.0-rc.12",
-        "feed": "^4.2.2",
-        "fs-extra": "^10.1.0",
-        "lodash": "^4.17.21",
-        "reading-time": "^1.5.0",
-        "tslib": "^2.4.0",
-        "unist-util-visit": "^2.0.3",
-        "utility-types": "^3.10.0",
-        "webpack": "^5.73.0"
-      },
-      "engines": {
-        "node": ">=16.14"
-      },
-      "peerDependencies": {
-        "react": "^16.8.4 || ^17.0.0",
-        "react-dom": "^16.8.4 || ^17.0.0"
-      }
-    },
-    "node_modules/@docusaurus/plugin-content-blog/node_modules/@docusaurus/core": {
-      "version": "2.3.1",
-      "resolved": "https://registry.npmjs.org/@docusaurus/core/-/core-2.3.1.tgz",
-      "integrity": "sha512-0Jd4jtizqnRAr7svWaBbbrCCN8mzBNd2xFLoT/IM7bGfFie5y58oz97KzXliwiLY3zWjqMXjQcuP1a5VgCv2JA==",
-      "dependencies": {
-        "@babel/core": "^7.18.6",
-        "@babel/generator": "^7.18.7",
-        "@babel/plugin-syntax-dynamic-import": "^7.8.3",
-        "@babel/plugin-transform-runtime": "^7.18.6",
-        "@babel/preset-env": "^7.18.6",
-        "@babel/preset-react": "^7.18.6",
-        "@babel/preset-typescript": "^7.18.6",
-        "@babel/runtime": "^7.18.6",
-        "@babel/runtime-corejs3": "^7.18.6",
-        "@babel/traverse": "^7.18.8",
-        "@docusaurus/cssnano-preset": "2.3.1",
-        "@docusaurus/logger": "2.3.1",
-        "@docusaurus/mdx-loader": "2.3.1",
-        "@docusaurus/react-loadable": "5.5.2",
-        "@docusaurus/utils": "2.3.1",
-        "@docusaurus/utils-common": "2.3.1",
-        "@docusaurus/utils-validation": "2.3.1",
-        "@slorber/static-site-generator-webpack-plugin": "^4.0.7",
-        "@svgr/webpack": "^6.2.1",
-        "autoprefixer": "^10.4.7",
-        "babel-loader": "^8.2.5",
-        "babel-plugin-dynamic-import-node": "^2.3.3",
-        "boxen": "^6.2.1",
-        "chalk": "^4.1.2",
-        "chokidar": "^3.5.3",
-        "clean-css": "^5.3.0",
-        "cli-table3": "^0.6.2",
-        "combine-promises": "^1.1.0",
-        "commander": "^5.1.0",
-        "copy-webpack-plugin": "^11.0.0",
-        "core-js": "^3.23.3",
-        "css-loader": "^6.7.1",
-        "css-minimizer-webpack-plugin": "^4.0.0",
-        "cssnano": "^5.1.12",
-        "del": "^6.1.1",
-        "detect-port": "^1.3.0",
-        "escape-html": "^1.0.3",
-        "eta": "^2.0.0",
-        "file-loader": "^6.2.0",
-        "fs-extra": "^10.1.0",
-        "html-minifier-terser": "^6.1.0",
-        "html-tags": "^3.2.0",
-        "html-webpack-plugin": "^5.5.0",
-        "import-fresh": "^3.3.0",
-        "leven": "^3.1.0",
-        "lodash": "^4.17.21",
-        "mini-css-extract-plugin": "^2.6.1",
-        "postcss": "^8.4.14",
-        "postcss-loader": "^7.0.0",
-        "prompts": "^2.4.2",
-        "react-dev-utils": "^12.0.1",
-        "react-helmet-async": "^1.3.0",
-        "react-loadable": "npm:@docusaurus/react-loadable@5.5.2",
-        "react-loadable-ssr-addon-v5-slorber": "^1.0.1",
-        "react-router": "^5.3.3",
-        "react-router-config": "^5.1.1",
-        "react-router-dom": "^5.3.3",
-        "rtl-detect": "^1.0.4",
-        "semver": "^7.3.7",
-        "serve-handler": "^6.1.3",
-        "shelljs": "^0.8.5",
-        "terser-webpack-plugin": "^5.3.3",
-        "tslib": "^2.4.0",
-        "update-notifier": "^5.1.0",
-        "url-loader": "^4.1.1",
-        "wait-on": "^6.0.1",
-        "webpack": "^5.73.0",
-        "webpack-bundle-analyzer": "^4.5.0",
-        "webpack-dev-server": "^4.9.3",
-        "webpack-merge": "^5.8.0",
-        "webpackbar": "^5.0.2"
-      },
-      "bin": {
-        "docusaurus": "bin/docusaurus.mjs"
-      },
-      "engines": {
-        "node": ">=16.14"
-      },
-      "peerDependencies": {
-        "react": "^16.8.4 || ^17.0.0",
-        "react-dom": "^16.8.4 || ^17.0.0"
-      }
-    },
-    "node_modules/@docusaurus/plugin-content-blog/node_modules/@docusaurus/cssnano-preset": {
-      "version": "2.3.1",
-      "resolved": "https://registry.npmjs.org/@docusaurus/cssnano-preset/-/cssnano-preset-2.3.1.tgz",
-      "integrity": "sha512-7mIhAROES6CY1GmCjR4CZkUfjTL6B3u6rKHK0ChQl2d1IevYXq/k/vFgvOrJfcKxiObpMnE9+X6R2Wt1KqxC6w==",
-      "dependencies": {
-        "cssnano-preset-advanced": "^5.3.8",
-        "postcss": "^8.4.14",
-        "postcss-sort-media-queries": "^4.2.1",
-        "tslib": "^2.4.0"
-      },
-      "engines": {
-        "node": ">=16.14"
-      }
-    },
-    "node_modules/@docusaurus/plugin-content-docs": {
-      "version": "2.3.1",
-      "resolved": "https://registry.npmjs.org/@docusaurus/plugin-content-docs/-/plugin-content-docs-2.3.1.tgz",
-      "integrity": "sha512-DxztTOBEruv7qFxqUtbsqXeNcHqcVEIEe+NQoI1oi2DBmKBhW/o0MIal8lt+9gvmpx3oYtlwmLOOGepxZgJGkw==",
-      "dependencies": {
-        "@docusaurus/core": "2.3.1",
-        "@docusaurus/logger": "2.3.1",
-        "@docusaurus/mdx-loader": "2.3.1",
-        "@docusaurus/module-type-aliases": "2.3.1",
-        "@docusaurus/types": "2.3.1",
-        "@docusaurus/utils": "2.3.1",
-        "@docusaurus/utils-validation": "2.3.1",
-        "@types/react-router-config": "^5.0.6",
-        "combine-promises": "^1.1.0",
-        "fs-extra": "^10.1.0",
-        "import-fresh": "^3.3.0",
-        "js-yaml": "^4.1.0",
-        "lodash": "^4.17.21",
-        "tslib": "^2.4.0",
-        "utility-types": "^3.10.0",
-        "webpack": "^5.73.0"
-      },
-      "engines": {
-        "node": ">=16.14"
-      },
-      "peerDependencies": {
-        "react": "^16.8.4 || ^17.0.0",
-        "react-dom": "^16.8.4 || ^17.0.0"
-      }
-    },
-    "node_modules/@docusaurus/plugin-content-docs/node_modules/@docusaurus/core": {
-      "version": "2.3.1",
-      "resolved": "https://registry.npmjs.org/@docusaurus/core/-/core-2.3.1.tgz",
-      "integrity": "sha512-0Jd4jtizqnRAr7svWaBbbrCCN8mzBNd2xFLoT/IM7bGfFie5y58oz97KzXliwiLY3zWjqMXjQcuP1a5VgCv2JA==",
-      "dependencies": {
-        "@babel/core": "^7.18.6",
-        "@babel/generator": "^7.18.7",
-        "@babel/plugin-syntax-dynamic-import": "^7.8.3",
-        "@babel/plugin-transform-runtime": "^7.18.6",
-        "@babel/preset-env": "^7.18.6",
-        "@babel/preset-react": "^7.18.6",
-        "@babel/preset-typescript": "^7.18.6",
-        "@babel/runtime": "^7.18.6",
-        "@babel/runtime-corejs3": "^7.18.6",
-        "@babel/traverse": "^7.18.8",
-        "@docusaurus/cssnano-preset": "2.3.1",
-        "@docusaurus/logger": "2.3.1",
-        "@docusaurus/mdx-loader": "2.3.1",
-        "@docusaurus/react-loadable": "5.5.2",
-        "@docusaurus/utils": "2.3.1",
-        "@docusaurus/utils-common": "2.3.1",
-        "@docusaurus/utils-validation": "2.3.1",
-        "@slorber/static-site-generator-webpack-plugin": "^4.0.7",
-        "@svgr/webpack": "^6.2.1",
-        "autoprefixer": "^10.4.7",
-        "babel-loader": "^8.2.5",
-        "babel-plugin-dynamic-import-node": "^2.3.3",
-        "boxen": "^6.2.1",
-        "chalk": "^4.1.2",
-        "chokidar": "^3.5.3",
-        "clean-css": "^5.3.0",
-        "cli-table3": "^0.6.2",
-        "combine-promises": "^1.1.0",
-        "commander": "^5.1.0",
-        "copy-webpack-plugin": "^11.0.0",
-        "core-js": "^3.23.3",
-        "css-loader": "^6.7.1",
-        "css-minimizer-webpack-plugin": "^4.0.0",
-        "cssnano": "^5.1.12",
-        "del": "^6.1.1",
-        "detect-port": "^1.3.0",
-        "escape-html": "^1.0.3",
-        "eta": "^2.0.0",
-        "file-loader": "^6.2.0",
-        "fs-extra": "^10.1.0",
-        "html-minifier-terser": "^6.1.0",
-        "html-tags": "^3.2.0",
-        "html-webpack-plugin": "^5.5.0",
-        "import-fresh": "^3.3.0",
-        "leven": "^3.1.0",
-        "lodash": "^4.17.21",
-        "mini-css-extract-plugin": "^2.6.1",
-        "postcss": "^8.4.14",
-        "postcss-loader": "^7.0.0",
-        "prompts": "^2.4.2",
-        "react-dev-utils": "^12.0.1",
-        "react-helmet-async": "^1.3.0",
-        "react-loadable": "npm:@docusaurus/react-loadable@5.5.2",
-        "react-loadable-ssr-addon-v5-slorber": "^1.0.1",
-        "react-router": "^5.3.3",
-        "react-router-config": "^5.1.1",
-        "react-router-dom": "^5.3.3",
-        "rtl-detect": "^1.0.4",
-        "semver": "^7.3.7",
-        "serve-handler": "^6.1.3",
-        "shelljs": "^0.8.5",
-        "terser-webpack-plugin": "^5.3.3",
-        "tslib": "^2.4.0",
-        "update-notifier": "^5.1.0",
-        "url-loader": "^4.1.1",
-        "wait-on": "^6.0.1",
-        "webpack": "^5.73.0",
-        "webpack-bundle-analyzer": "^4.5.0",
-        "webpack-dev-server": "^4.9.3",
-        "webpack-merge": "^5.8.0",
-        "webpackbar": "^5.0.2"
-      },
-      "bin": {
-        "docusaurus": "bin/docusaurus.mjs"
-      },
-      "engines": {
-        "node": ">=16.14"
-      },
-      "peerDependencies": {
-        "react": "^16.8.4 || ^17.0.0",
-        "react-dom": "^16.8.4 || ^17.0.0"
-      }
-    },
-    "node_modules/@docusaurus/plugin-content-docs/node_modules/@docusaurus/cssnano-preset": {
-      "version": "2.3.1",
-      "resolved": "https://registry.npmjs.org/@docusaurus/cssnano-preset/-/cssnano-preset-2.3.1.tgz",
-      "integrity": "sha512-7mIhAROES6CY1GmCjR4CZkUfjTL6B3u6rKHK0ChQl2d1IevYXq/k/vFgvOrJfcKxiObpMnE9+X6R2Wt1KqxC6w==",
-      "dependencies": {
-        "cssnano-preset-advanced": "^5.3.8",
-        "postcss": "^8.4.14",
-        "postcss-sort-media-queries": "^4.2.1",
-        "tslib": "^2.4.0"
-      },
-      "engines": {
-        "node": ">=16.14"
-      }
-    },
-    "node_modules/@docusaurus/plugin-content-docs/node_modules/@docusaurus/module-type-aliases": {
-      "version": "2.3.1",
-      "resolved": "https://registry.npmjs.org/@docusaurus/module-type-aliases/-/module-type-aliases-2.3.1.tgz",
-      "integrity": "sha512-6KkxfAVOJqIUynTRb/tphYCl+co3cP0PlHiMDbi+SzmYxMdgIrwYqH9yAnGSDoN6Jk2ZE/JY/Azs/8LPgKP48A==",
-      "dependencies": {
-        "@docusaurus/react-loadable": "5.5.2",
-        "@docusaurus/types": "2.3.1",
-        "@types/history": "^4.7.11",
-        "@types/react": "*",
-        "@types/react-router-config": "*",
-        "@types/react-router-dom": "*",
-        "react-helmet-async": "*",
-        "react-loadable": "npm:@docusaurus/react-loadable@5.5.2"
-      },
-      "peerDependencies": {
-        "react": "*",
-        "react-dom": "*"
-      }
-    },
-    "node_modules/@docusaurus/plugin-content-pages": {
-      "version": "2.3.1",
-      "resolved": "https://registry.npmjs.org/@docusaurus/plugin-content-pages/-/plugin-content-pages-2.3.1.tgz",
-      "integrity": "sha512-E80UL6hvKm5VVw8Ka8YaVDtO6kWWDVUK4fffGvkpQ/AJQDOg99LwOXKujPoICC22nUFTsZ2Hp70XvpezCsFQaA==",
-      "dependencies": {
-        "@docusaurus/core": "2.3.1",
-        "@docusaurus/mdx-loader": "2.3.1",
-        "@docusaurus/types": "2.3.1",
-        "@docusaurus/utils": "2.3.1",
-        "@docusaurus/utils-validation": "2.3.1",
-        "fs-extra": "^10.1.0",
-        "tslib": "^2.4.0",
-        "webpack": "^5.73.0"
-      },
-      "engines": {
-        "node": ">=16.14"
-      },
-      "peerDependencies": {
-        "react": "^16.8.4 || ^17.0.0",
-        "react-dom": "^16.8.4 || ^17.0.0"
-      }
-    },
-    "node_modules/@docusaurus/plugin-content-pages/node_modules/@docusaurus/core": {
-      "version": "2.3.1",
-      "resolved": "https://registry.npmjs.org/@docusaurus/core/-/core-2.3.1.tgz",
-      "integrity": "sha512-0Jd4jtizqnRAr7svWaBbbrCCN8mzBNd2xFLoT/IM7bGfFie5y58oz97KzXliwiLY3zWjqMXjQcuP1a5VgCv2JA==",
-      "dependencies": {
-        "@babel/core": "^7.18.6",
-        "@babel/generator": "^7.18.7",
-        "@babel/plugin-syntax-dynamic-import": "^7.8.3",
-        "@babel/plugin-transform-runtime": "^7.18.6",
-        "@babel/preset-env": "^7.18.6",
-        "@babel/preset-react": "^7.18.6",
-        "@babel/preset-typescript": "^7.18.6",
-        "@babel/runtime": "^7.18.6",
-        "@babel/runtime-corejs3": "^7.18.6",
-        "@babel/traverse": "^7.18.8",
-        "@docusaurus/cssnano-preset": "2.3.1",
-        "@docusaurus/logger": "2.3.1",
-        "@docusaurus/mdx-loader": "2.3.1",
-        "@docusaurus/react-loadable": "5.5.2",
-        "@docusaurus/utils": "2.3.1",
-        "@docusaurus/utils-common": "2.3.1",
-        "@docusaurus/utils-validation": "2.3.1",
-        "@slorber/static-site-generator-webpack-plugin": "^4.0.7",
-        "@svgr/webpack": "^6.2.1",
-        "autoprefixer": "^10.4.7",
-        "babel-loader": "^8.2.5",
-        "babel-plugin-dynamic-import-node": "^2.3.3",
-        "boxen": "^6.2.1",
-        "chalk": "^4.1.2",
-        "chokidar": "^3.5.3",
-        "clean-css": "^5.3.0",
-        "cli-table3": "^0.6.2",
-        "combine-promises": "^1.1.0",
-        "commander": "^5.1.0",
-        "copy-webpack-plugin": "^11.0.0",
-        "core-js": "^3.23.3",
-        "css-loader": "^6.7.1",
-        "css-minimizer-webpack-plugin": "^4.0.0",
-        "cssnano": "^5.1.12",
-        "del": "^6.1.1",
-        "detect-port": "^1.3.0",
-        "escape-html": "^1.0.3",
-        "eta": "^2.0.0",
-        "file-loader": "^6.2.0",
-        "fs-extra": "^10.1.0",
-        "html-minifier-terser": "^6.1.0",
-        "html-tags": "^3.2.0",
-        "html-webpack-plugin": "^5.5.0",
-        "import-fresh": "^3.3.0",
-        "leven": "^3.1.0",
-        "lodash": "^4.17.21",
-        "mini-css-extract-plugin": "^2.6.1",
-        "postcss": "^8.4.14",
-        "postcss-loader": "^7.0.0",
-        "prompts": "^2.4.2",
-        "react-dev-utils": "^12.0.1",
-        "react-helmet-async": "^1.3.0",
-        "react-loadable": "npm:@docusaurus/react-loadable@5.5.2",
-        "react-loadable-ssr-addon-v5-slorber": "^1.0.1",
-        "react-router": "^5.3.3",
-        "react-router-config": "^5.1.1",
-        "react-router-dom": "^5.3.3",
-        "rtl-detect": "^1.0.4",
-        "semver": "^7.3.7",
-        "serve-handler": "^6.1.3",
-        "shelljs": "^0.8.5",
-        "terser-webpack-plugin": "^5.3.3",
-        "tslib": "^2.4.0",
-        "update-notifier": "^5.1.0",
-        "url-loader": "^4.1.1",
-        "wait-on": "^6.0.1",
-        "webpack": "^5.73.0",
-        "webpack-bundle-analyzer": "^4.5.0",
-        "webpack-dev-server": "^4.9.3",
-        "webpack-merge": "^5.8.0",
-        "webpackbar": "^5.0.2"
-      },
-      "bin": {
-        "docusaurus": "bin/docusaurus.mjs"
-      },
-      "engines": {
-        "node": ">=16.14"
-      },
-      "peerDependencies": {
-        "react": "^16.8.4 || ^17.0.0",
-        "react-dom": "^16.8.4 || ^17.0.0"
-      }
-    },
-    "node_modules/@docusaurus/plugin-content-pages/node_modules/@docusaurus/cssnano-preset": {
-      "version": "2.3.1",
-      "resolved": "https://registry.npmjs.org/@docusaurus/cssnano-preset/-/cssnano-preset-2.3.1.tgz",
-      "integrity": "sha512-7mIhAROES6CY1GmCjR4CZkUfjTL6B3u6rKHK0ChQl2d1IevYXq/k/vFgvOrJfcKxiObpMnE9+X6R2Wt1KqxC6w==",
-      "dependencies": {
-        "cssnano-preset-advanced": "^5.3.8",
-        "postcss": "^8.4.14",
-        "postcss-sort-media-queries": "^4.2.1",
-        "tslib": "^2.4.0"
-      },
-      "engines": {
-        "node": ">=16.14"
-      }
-    },
-    "node_modules/@docusaurus/plugin-debug": {
-      "version": "2.3.1",
-      "resolved": "https://registry.npmjs.org/@docusaurus/plugin-debug/-/plugin-debug-2.3.1.tgz",
-      "integrity": "sha512-Ujpml1Ppg4geB/2hyu2diWnO49az9U2bxM9Shen7b6qVcyFisNJTkVG2ocvLC7wM1efTJcUhBO6zAku2vKJGMw==",
-      "dependencies": {
-        "@docusaurus/core": "2.3.1",
-        "@docusaurus/types": "2.3.1",
-        "@docusaurus/utils": "2.3.1",
-        "fs-extra": "^10.1.0",
-        "react-json-view": "^1.21.3",
-        "tslib": "^2.4.0"
-      },
-      "engines": {
-        "node": ">=16.14"
-      },
-      "peerDependencies": {
-        "react": "^16.8.4 || ^17.0.0",
-        "react-dom": "^16.8.4 || ^17.0.0"
-      }
-    },
-    "node_modules/@docusaurus/plugin-debug/node_modules/@docusaurus/core": {
-      "version": "2.3.1",
-      "resolved": "https://registry.npmjs.org/@docusaurus/core/-/core-2.3.1.tgz",
-      "integrity": "sha512-0Jd4jtizqnRAr7svWaBbbrCCN8mzBNd2xFLoT/IM7bGfFie5y58oz97KzXliwiLY3zWjqMXjQcuP1a5VgCv2JA==",
-      "dependencies": {
-        "@babel/core": "^7.18.6",
-        "@babel/generator": "^7.18.7",
-        "@babel/plugin-syntax-dynamic-import": "^7.8.3",
-        "@babel/plugin-transform-runtime": "^7.18.6",
-        "@babel/preset-env": "^7.18.6",
-        "@babel/preset-react": "^7.18.6",
-        "@babel/preset-typescript": "^7.18.6",
-        "@babel/runtime": "^7.18.6",
-        "@babel/runtime-corejs3": "^7.18.6",
-        "@babel/traverse": "^7.18.8",
-        "@docusaurus/cssnano-preset": "2.3.1",
-        "@docusaurus/logger": "2.3.1",
-        "@docusaurus/mdx-loader": "2.3.1",
-        "@docusaurus/react-loadable": "5.5.2",
-        "@docusaurus/utils": "2.3.1",
-        "@docusaurus/utils-common": "2.3.1",
-        "@docusaurus/utils-validation": "2.3.1",
-        "@slorber/static-site-generator-webpack-plugin": "^4.0.7",
-        "@svgr/webpack": "^6.2.1",
-        "autoprefixer": "^10.4.7",
-        "babel-loader": "^8.2.5",
-        "babel-plugin-dynamic-import-node": "^2.3.3",
-        "boxen": "^6.2.1",
-        "chalk": "^4.1.2",
-        "chokidar": "^3.5.3",
-        "clean-css": "^5.3.0",
-        "cli-table3": "^0.6.2",
-        "combine-promises": "^1.1.0",
-        "commander": "^5.1.0",
-        "copy-webpack-plugin": "^11.0.0",
-        "core-js": "^3.23.3",
-        "css-loader": "^6.7.1",
-        "css-minimizer-webpack-plugin": "^4.0.0",
-        "cssnano": "^5.1.12",
-        "del": "^6.1.1",
-        "detect-port": "^1.3.0",
-        "escape-html": "^1.0.3",
-        "eta": "^2.0.0",
-        "file-loader": "^6.2.0",
-        "fs-extra": "^10.1.0",
-        "html-minifier-terser": "^6.1.0",
-        "html-tags": "^3.2.0",
-        "html-webpack-plugin": "^5.5.0",
-        "import-fresh": "^3.3.0",
-        "leven": "^3.1.0",
-        "lodash": "^4.17.21",
-        "mini-css-extract-plugin": "^2.6.1",
-        "postcss": "^8.4.14",
-        "postcss-loader": "^7.0.0",
-        "prompts": "^2.4.2",
-        "react-dev-utils": "^12.0.1",
-        "react-helmet-async": "^1.3.0",
-        "react-loadable": "npm:@docusaurus/react-loadable@5.5.2",
-        "react-loadable-ssr-addon-v5-slorber": "^1.0.1",
-        "react-router": "^5.3.3",
-        "react-router-config": "^5.1.1",
-        "react-router-dom": "^5.3.3",
-        "rtl-detect": "^1.0.4",
-        "semver": "^7.3.7",
-        "serve-handler": "^6.1.3",
-        "shelljs": "^0.8.5",
-        "terser-webpack-plugin": "^5.3.3",
-        "tslib": "^2.4.0",
-        "update-notifier": "^5.1.0",
-        "url-loader": "^4.1.1",
-        "wait-on": "^6.0.1",
-        "webpack": "^5.73.0",
-        "webpack-bundle-analyzer": "^4.5.0",
-        "webpack-dev-server": "^4.9.3",
-        "webpack-merge": "^5.8.0",
-        "webpackbar": "^5.0.2"
-      },
-      "bin": {
-        "docusaurus": "bin/docusaurus.mjs"
-      },
-      "engines": {
-        "node": ">=16.14"
-      },
-      "peerDependencies": {
-        "react": "^16.8.4 || ^17.0.0",
-        "react-dom": "^16.8.4 || ^17.0.0"
-      }
-    },
-    "node_modules/@docusaurus/plugin-debug/node_modules/@docusaurus/cssnano-preset": {
-      "version": "2.3.1",
-      "resolved": "https://registry.npmjs.org/@docusaurus/cssnano-preset/-/cssnano-preset-2.3.1.tgz",
-      "integrity": "sha512-7mIhAROES6CY1GmCjR4CZkUfjTL6B3u6rKHK0ChQl2d1IevYXq/k/vFgvOrJfcKxiObpMnE9+X6R2Wt1KqxC6w==",
-      "dependencies": {
-        "cssnano-preset-advanced": "^5.3.8",
-        "postcss": "^8.4.14",
-        "postcss-sort-media-queries": "^4.2.1",
-        "tslib": "^2.4.0"
-      },
-      "engines": {
-        "node": ">=16.14"
-      }
-    },
-    "node_modules/@docusaurus/plugin-google-analytics": {
-      "version": "2.3.1",
-      "resolved": "https://registry.npmjs.org/@docusaurus/plugin-google-analytics/-/plugin-google-analytics-2.3.1.tgz",
-      "integrity": "sha512-OHip0GQxKOFU8n7gkt3TM4HOYTXPCFDjqKbMClDD3KaDnyTuMp/Zvd9HSr770lLEscgPWIvzhJByRAClqsUWiQ==",
-      "dependencies": {
-        "@docusaurus/core": "2.3.1",
-        "@docusaurus/types": "2.3.1",
-        "@docusaurus/utils-validation": "2.3.1",
-        "tslib": "^2.4.0"
-      },
-      "engines": {
-        "node": ">=16.14"
-      },
-      "peerDependencies": {
-        "react": "^16.8.4 || ^17.0.0",
-        "react-dom": "^16.8.4 || ^17.0.0"
-      }
-    },
-    "node_modules/@docusaurus/plugin-google-analytics/node_modules/@docusaurus/core": {
-      "version": "2.3.1",
-      "resolved": "https://registry.npmjs.org/@docusaurus/core/-/core-2.3.1.tgz",
-      "integrity": "sha512-0Jd4jtizqnRAr7svWaBbbrCCN8mzBNd2xFLoT/IM7bGfFie5y58oz97KzXliwiLY3zWjqMXjQcuP1a5VgCv2JA==",
-      "dependencies": {
-        "@babel/core": "^7.18.6",
-        "@babel/generator": "^7.18.7",
-        "@babel/plugin-syntax-dynamic-import": "^7.8.3",
-        "@babel/plugin-transform-runtime": "^7.18.6",
-        "@babel/preset-env": "^7.18.6",
-        "@babel/preset-react": "^7.18.6",
-        "@babel/preset-typescript": "^7.18.6",
-        "@babel/runtime": "^7.18.6",
-        "@babel/runtime-corejs3": "^7.18.6",
-        "@babel/traverse": "^7.18.8",
-        "@docusaurus/cssnano-preset": "2.3.1",
-        "@docusaurus/logger": "2.3.1",
-        "@docusaurus/mdx-loader": "2.3.1",
-        "@docusaurus/react-loadable": "5.5.2",
-        "@docusaurus/utils": "2.3.1",
-        "@docusaurus/utils-common": "2.3.1",
-        "@docusaurus/utils-validation": "2.3.1",
-        "@slorber/static-site-generator-webpack-plugin": "^4.0.7",
-        "@svgr/webpack": "^6.2.1",
-        "autoprefixer": "^10.4.7",
-        "babel-loader": "^8.2.5",
-        "babel-plugin-dynamic-import-node": "^2.3.3",
-        "boxen": "^6.2.1",
-        "chalk": "^4.1.2",
-        "chokidar": "^3.5.3",
-        "clean-css": "^5.3.0",
-        "cli-table3": "^0.6.2",
-        "combine-promises": "^1.1.0",
-        "commander": "^5.1.0",
-        "copy-webpack-plugin": "^11.0.0",
-        "core-js": "^3.23.3",
-        "css-loader": "^6.7.1",
-        "css-minimizer-webpack-plugin": "^4.0.0",
-        "cssnano": "^5.1.12",
-        "del": "^6.1.1",
-        "detect-port": "^1.3.0",
-        "escape-html": "^1.0.3",
-        "eta": "^2.0.0",
-        "file-loader": "^6.2.0",
-        "fs-extra": "^10.1.0",
-        "html-minifier-terser": "^6.1.0",
-        "html-tags": "^3.2.0",
-        "html-webpack-plugin": "^5.5.0",
-        "import-fresh": "^3.3.0",
-        "leven": "^3.1.0",
-        "lodash": "^4.17.21",
-        "mini-css-extract-plugin": "^2.6.1",
-        "postcss": "^8.4.14",
-        "postcss-loader": "^7.0.0",
-        "prompts": "^2.4.2",
-        "react-dev-utils": "^12.0.1",
-        "react-helmet-async": "^1.3.0",
-        "react-loadable": "npm:@docusaurus/react-loadable@5.5.2",
-        "react-loadable-ssr-addon-v5-slorber": "^1.0.1",
-        "react-router": "^5.3.3",
-        "react-router-config": "^5.1.1",
-        "react-router-dom": "^5.3.3",
-        "rtl-detect": "^1.0.4",
-        "semver": "^7.3.7",
-        "serve-handler": "^6.1.3",
-        "shelljs": "^0.8.5",
-        "terser-webpack-plugin": "^5.3.3",
-        "tslib": "^2.4.0",
-        "update-notifier": "^5.1.0",
-        "url-loader": "^4.1.1",
-        "wait-on": "^6.0.1",
-        "webpack": "^5.73.0",
-        "webpack-bundle-analyzer": "^4.5.0",
-        "webpack-dev-server": "^4.9.3",
-        "webpack-merge": "^5.8.0",
-        "webpackbar": "^5.0.2"
-      },
-      "bin": {
-        "docusaurus": "bin/docusaurus.mjs"
-      },
-      "engines": {
-        "node": ">=16.14"
-      },
-      "peerDependencies": {
-        "react": "^16.8.4 || ^17.0.0",
-        "react-dom": "^16.8.4 || ^17.0.0"
-      }
-    },
-    "node_modules/@docusaurus/plugin-google-analytics/node_modules/@docusaurus/cssnano-preset": {
-      "version": "2.3.1",
-      "resolved": "https://registry.npmjs.org/@docusaurus/cssnano-preset/-/cssnano-preset-2.3.1.tgz",
-      "integrity": "sha512-7mIhAROES6CY1GmCjR4CZkUfjTL6B3u6rKHK0ChQl2d1IevYXq/k/vFgvOrJfcKxiObpMnE9+X6R2Wt1KqxC6w==",
-      "dependencies": {
-        "cssnano-preset-advanced": "^5.3.8",
-        "postcss": "^8.4.14",
-        "postcss-sort-media-queries": "^4.2.1",
-        "tslib": "^2.4.0"
-      },
-      "engines": {
-        "node": ">=16.14"
-      }
-    },
-    "node_modules/@docusaurus/plugin-google-gtag": {
-      "version": "2.3.1",
-      "resolved": "https://registry.npmjs.org/@docusaurus/plugin-google-gtag/-/plugin-google-gtag-2.3.1.tgz",
-      "integrity": "sha512-uXtDhfu4+Hm+oqWUySr3DNI5cWC/rmP6XJyAk83Heor3dFjZqDwCbkX8yWPywkRiWev3Dk/rVF8lEn0vIGVocA==",
-      "dependencies": {
-        "@docusaurus/core": "2.3.1",
-        "@docusaurus/types": "2.3.1",
-        "@docusaurus/utils-validation": "2.3.1",
-        "tslib": "^2.4.0"
-      },
-      "engines": {
-        "node": ">=16.14"
-      },
-      "peerDependencies": {
-        "react": "^16.8.4 || ^17.0.0",
-        "react-dom": "^16.8.4 || ^17.0.0"
-      }
-    },
-    "node_modules/@docusaurus/plugin-google-gtag/node_modules/@docusaurus/core": {
-      "version": "2.3.1",
-      "resolved": "https://registry.npmjs.org/@docusaurus/core/-/core-2.3.1.tgz",
-      "integrity": "sha512-0Jd4jtizqnRAr7svWaBbbrCCN8mzBNd2xFLoT/IM7bGfFie5y58oz97KzXliwiLY3zWjqMXjQcuP1a5VgCv2JA==",
-      "dependencies": {
-        "@babel/core": "^7.18.6",
-        "@babel/generator": "^7.18.7",
-        "@babel/plugin-syntax-dynamic-import": "^7.8.3",
-        "@babel/plugin-transform-runtime": "^7.18.6",
-        "@babel/preset-env": "^7.18.6",
-        "@babel/preset-react": "^7.18.6",
-        "@babel/preset-typescript": "^7.18.6",
-        "@babel/runtime": "^7.18.6",
-        "@babel/runtime-corejs3": "^7.18.6",
-        "@babel/traverse": "^7.18.8",
-        "@docusaurus/cssnano-preset": "2.3.1",
-        "@docusaurus/logger": "2.3.1",
-        "@docusaurus/mdx-loader": "2.3.1",
-        "@docusaurus/react-loadable": "5.5.2",
-        "@docusaurus/utils": "2.3.1",
-        "@docusaurus/utils-common": "2.3.1",
-        "@docusaurus/utils-validation": "2.3.1",
-        "@slorber/static-site-generator-webpack-plugin": "^4.0.7",
-        "@svgr/webpack": "^6.2.1",
-        "autoprefixer": "^10.4.7",
-        "babel-loader": "^8.2.5",
-        "babel-plugin-dynamic-import-node": "^2.3.3",
-        "boxen": "^6.2.1",
-        "chalk": "^4.1.2",
-        "chokidar": "^3.5.3",
-        "clean-css": "^5.3.0",
-        "cli-table3": "^0.6.2",
-        "combine-promises": "^1.1.0",
-        "commander": "^5.1.0",
-        "copy-webpack-plugin": "^11.0.0",
-        "core-js": "^3.23.3",
-        "css-loader": "^6.7.1",
-        "css-minimizer-webpack-plugin": "^4.0.0",
-        "cssnano": "^5.1.12",
-        "del": "^6.1.1",
-        "detect-port": "^1.3.0",
-        "escape-html": "^1.0.3",
-        "eta": "^2.0.0",
-        "file-loader": "^6.2.0",
-        "fs-extra": "^10.1.0",
-        "html-minifier-terser": "^6.1.0",
-        "html-tags": "^3.2.0",
-        "html-webpack-plugin": "^5.5.0",
-        "import-fresh": "^3.3.0",
-        "leven": "^3.1.0",
-        "lodash": "^4.17.21",
-        "mini-css-extract-plugin": "^2.6.1",
-        "postcss": "^8.4.14",
-        "postcss-loader": "^7.0.0",
-        "prompts": "^2.4.2",
-        "react-dev-utils": "^12.0.1",
-        "react-helmet-async": "^1.3.0",
-        "react-loadable": "npm:@docusaurus/react-loadable@5.5.2",
-        "react-loadable-ssr-addon-v5-slorber": "^1.0.1",
-        "react-router": "^5.3.3",
-        "react-router-config": "^5.1.1",
-        "react-router-dom": "^5.3.3",
-        "rtl-detect": "^1.0.4",
-        "semver": "^7.3.7",
-        "serve-handler": "^6.1.3",
-        "shelljs": "^0.8.5",
-        "terser-webpack-plugin": "^5.3.3",
-        "tslib": "^2.4.0",
-        "update-notifier": "^5.1.0",
-        "url-loader": "^4.1.1",
-        "wait-on": "^6.0.1",
-        "webpack": "^5.73.0",
-        "webpack-bundle-analyzer": "^4.5.0",
-        "webpack-dev-server": "^4.9.3",
-        "webpack-merge": "^5.8.0",
-        "webpackbar": "^5.0.2"
-      },
-      "bin": {
-        "docusaurus": "bin/docusaurus.mjs"
-      },
-      "engines": {
-        "node": ">=16.14"
-      },
-      "peerDependencies": {
-        "react": "^16.8.4 || ^17.0.0",
-        "react-dom": "^16.8.4 || ^17.0.0"
-      }
-    },
-    "node_modules/@docusaurus/plugin-google-gtag/node_modules/@docusaurus/cssnano-preset": {
-      "version": "2.3.1",
-      "resolved": "https://registry.npmjs.org/@docusaurus/cssnano-preset/-/cssnano-preset-2.3.1.tgz",
-      "integrity": "sha512-7mIhAROES6CY1GmCjR4CZkUfjTL6B3u6rKHK0ChQl2d1IevYXq/k/vFgvOrJfcKxiObpMnE9+X6R2Wt1KqxC6w==",
-      "dependencies": {
-        "cssnano-preset-advanced": "^5.3.8",
-        "postcss": "^8.4.14",
-        "postcss-sort-media-queries": "^4.2.1",
-        "tslib": "^2.4.0"
-      },
-      "engines": {
-        "node": ">=16.14"
-      }
-    },
-    "node_modules/@docusaurus/plugin-google-tag-manager": {
-      "version": "2.3.1",
-      "resolved": "https://registry.npmjs.org/@docusaurus/plugin-google-tag-manager/-/plugin-google-tag-manager-2.3.1.tgz",
-      "integrity": "sha512-Ww2BPEYSqg8q8tJdLYPFFM3FMDBCVhEM4UUqKzJaiRMx3NEoly3qqDRAoRDGdIhlC//Rf0iJV9cWAoq2m6k3sw==",
-      "dependencies": {
-        "@docusaurus/core": "2.3.1",
-        "@docusaurus/types": "2.3.1",
-        "@docusaurus/utils-validation": "2.3.1",
-        "tslib": "^2.4.0"
-      },
-      "engines": {
-        "node": ">=16.14"
-      },
-      "peerDependencies": {
-        "react": "^16.8.4 || ^17.0.0",
-        "react-dom": "^16.8.4 || ^17.0.0"
-      }
-    },
-    "node_modules/@docusaurus/plugin-google-tag-manager/node_modules/@docusaurus/core": {
-      "version": "2.3.1",
-      "resolved": "https://registry.npmjs.org/@docusaurus/core/-/core-2.3.1.tgz",
-      "integrity": "sha512-0Jd4jtizqnRAr7svWaBbbrCCN8mzBNd2xFLoT/IM7bGfFie5y58oz97KzXliwiLY3zWjqMXjQcuP1a5VgCv2JA==",
-      "dependencies": {
-        "@babel/core": "^7.18.6",
-        "@babel/generator": "^7.18.7",
-        "@babel/plugin-syntax-dynamic-import": "^7.8.3",
-        "@babel/plugin-transform-runtime": "^7.18.6",
-        "@babel/preset-env": "^7.18.6",
-        "@babel/preset-react": "^7.18.6",
-        "@babel/preset-typescript": "^7.18.6",
-        "@babel/runtime": "^7.18.6",
-        "@babel/runtime-corejs3": "^7.18.6",
-        "@babel/traverse": "^7.18.8",
-        "@docusaurus/cssnano-preset": "2.3.1",
-        "@docusaurus/logger": "2.3.1",
-        "@docusaurus/mdx-loader": "2.3.1",
-        "@docusaurus/react-loadable": "5.5.2",
-        "@docusaurus/utils": "2.3.1",
-        "@docusaurus/utils-common": "2.3.1",
-        "@docusaurus/utils-validation": "2.3.1",
-        "@slorber/static-site-generator-webpack-plugin": "^4.0.7",
-        "@svgr/webpack": "^6.2.1",
-        "autoprefixer": "^10.4.7",
-        "babel-loader": "^8.2.5",
-        "babel-plugin-dynamic-import-node": "^2.3.3",
-        "boxen": "^6.2.1",
-        "chalk": "^4.1.2",
-        "chokidar": "^3.5.3",
-        "clean-css": "^5.3.0",
-        "cli-table3": "^0.6.2",
-        "combine-promises": "^1.1.0",
-        "commander": "^5.1.0",
-        "copy-webpack-plugin": "^11.0.0",
-        "core-js": "^3.23.3",
-        "css-loader": "^6.7.1",
-        "css-minimizer-webpack-plugin": "^4.0.0",
-        "cssnano": "^5.1.12",
-        "del": "^6.1.1",
-        "detect-port": "^1.3.0",
-        "escape-html": "^1.0.3",
-        "eta": "^2.0.0",
-        "file-loader": "^6.2.0",
-        "fs-extra": "^10.1.0",
-        "html-minifier-terser": "^6.1.0",
-        "html-tags": "^3.2.0",
-        "html-webpack-plugin": "^5.5.0",
-        "import-fresh": "^3.3.0",
-        "leven": "^3.1.0",
-        "lodash": "^4.17.21",
-        "mini-css-extract-plugin": "^2.6.1",
-        "postcss": "^8.4.14",
-        "postcss-loader": "^7.0.0",
-        "prompts": "^2.4.2",
-        "react-dev-utils": "^12.0.1",
-        "react-helmet-async": "^1.3.0",
-        "react-loadable": "npm:@docusaurus/react-loadable@5.5.2",
-        "react-loadable-ssr-addon-v5-slorber": "^1.0.1",
-        "react-router": "^5.3.3",
-        "react-router-config": "^5.1.1",
-        "react-router-dom": "^5.3.3",
-        "rtl-detect": "^1.0.4",
-        "semver": "^7.3.7",
-        "serve-handler": "^6.1.3",
-        "shelljs": "^0.8.5",
-        "terser-webpack-plugin": "^5.3.3",
-        "tslib": "^2.4.0",
-        "update-notifier": "^5.1.0",
-        "url-loader": "^4.1.1",
-        "wait-on": "^6.0.1",
-        "webpack": "^5.73.0",
-        "webpack-bundle-analyzer": "^4.5.0",
-        "webpack-dev-server": "^4.9.3",
-        "webpack-merge": "^5.8.0",
-        "webpackbar": "^5.0.2"
-      },
-      "bin": {
-        "docusaurus": "bin/docusaurus.mjs"
-      },
-      "engines": {
-        "node": ">=16.14"
-      },
-      "peerDependencies": {
-        "react": "^16.8.4 || ^17.0.0",
-        "react-dom": "^16.8.4 || ^17.0.0"
-      }
-    },
-    "node_modules/@docusaurus/plugin-google-tag-manager/node_modules/@docusaurus/cssnano-preset": {
-      "version": "2.3.1",
-      "resolved": "https://registry.npmjs.org/@docusaurus/cssnano-preset/-/cssnano-preset-2.3.1.tgz",
-      "integrity": "sha512-7mIhAROES6CY1GmCjR4CZkUfjTL6B3u6rKHK0ChQl2d1IevYXq/k/vFgvOrJfcKxiObpMnE9+X6R2Wt1KqxC6w==",
-      "dependencies": {
-        "cssnano-preset-advanced": "^5.3.8",
-        "postcss": "^8.4.14",
-        "postcss-sort-media-queries": "^4.2.1",
-        "tslib": "^2.4.0"
-      },
-      "engines": {
-        "node": ">=16.14"
-      }
-    },
-    "node_modules/@docusaurus/plugin-sitemap": {
-      "version": "2.3.1",
-      "resolved": "https://registry.npmjs.org/@docusaurus/plugin-sitemap/-/plugin-sitemap-2.3.1.tgz",
-      "integrity": "sha512-8Yxile/v6QGYV9vgFiYL+8d2N4z4Er3pSHsrD08c5XI8bUXxTppMwjarDUTH/TRTfgAWotRbhJ6WZLyajLpozA==",
-      "dependencies": {
-        "@docusaurus/core": "2.3.1",
-        "@docusaurus/logger": "2.3.1",
-        "@docusaurus/types": "2.3.1",
-        "@docusaurus/utils": "2.3.1",
-        "@docusaurus/utils-common": "2.3.1",
-        "@docusaurus/utils-validation": "2.3.1",
-        "fs-extra": "^10.1.0",
-        "sitemap": "^7.1.1",
-        "tslib": "^2.4.0"
-      },
-      "engines": {
-        "node": ">=16.14"
-      },
-      "peerDependencies": {
-        "react": "^16.8.4 || ^17.0.0",
-        "react-dom": "^16.8.4 || ^17.0.0"
-      }
-    },
-    "node_modules/@docusaurus/plugin-sitemap/node_modules/@docusaurus/core": {
-      "version": "2.3.1",
-      "resolved": "https://registry.npmjs.org/@docusaurus/core/-/core-2.3.1.tgz",
-      "integrity": "sha512-0Jd4jtizqnRAr7svWaBbbrCCN8mzBNd2xFLoT/IM7bGfFie5y58oz97KzXliwiLY3zWjqMXjQcuP1a5VgCv2JA==",
-      "dependencies": {
-        "@babel/core": "^7.18.6",
-        "@babel/generator": "^7.18.7",
-        "@babel/plugin-syntax-dynamic-import": "^7.8.3",
-        "@babel/plugin-transform-runtime": "^7.18.6",
-        "@babel/preset-env": "^7.18.6",
-        "@babel/preset-react": "^7.18.6",
-        "@babel/preset-typescript": "^7.18.6",
-        "@babel/runtime": "^7.18.6",
-        "@babel/runtime-corejs3": "^7.18.6",
-        "@babel/traverse": "^7.18.8",
-        "@docusaurus/cssnano-preset": "2.3.1",
-        "@docusaurus/logger": "2.3.1",
-        "@docusaurus/mdx-loader": "2.3.1",
-        "@docusaurus/react-loadable": "5.5.2",
-        "@docusaurus/utils": "2.3.1",
-        "@docusaurus/utils-common": "2.3.1",
-        "@docusaurus/utils-validation": "2.3.1",
-        "@slorber/static-site-generator-webpack-plugin": "^4.0.7",
-        "@svgr/webpack": "^6.2.1",
-        "autoprefixer": "^10.4.7",
-        "babel-loader": "^8.2.5",
-        "babel-plugin-dynamic-import-node": "^2.3.3",
-        "boxen": "^6.2.1",
-        "chalk": "^4.1.2",
-        "chokidar": "^3.5.3",
-        "clean-css": "^5.3.0",
-        "cli-table3": "^0.6.2",
-        "combine-promises": "^1.1.0",
-        "commander": "^5.1.0",
-        "copy-webpack-plugin": "^11.0.0",
-        "core-js": "^3.23.3",
-        "css-loader": "^6.7.1",
-        "css-minimizer-webpack-plugin": "^4.0.0",
-        "cssnano": "^5.1.12",
-        "del": "^6.1.1",
-        "detect-port": "^1.3.0",
-        "escape-html": "^1.0.3",
-        "eta": "^2.0.0",
-        "file-loader": "^6.2.0",
-        "fs-extra": "^10.1.0",
-        "html-minifier-terser": "^6.1.0",
-        "html-tags": "^3.2.0",
-        "html-webpack-plugin": "^5.5.0",
-        "import-fresh": "^3.3.0",
-        "leven": "^3.1.0",
-        "lodash": "^4.17.21",
-        "mini-css-extract-plugin": "^2.6.1",
-        "postcss": "^8.4.14",
-        "postcss-loader": "^7.0.0",
-        "prompts": "^2.4.2",
-        "react-dev-utils": "^12.0.1",
-        "react-helmet-async": "^1.3.0",
-        "react-loadable": "npm:@docusaurus/react-loadable@5.5.2",
-        "react-loadable-ssr-addon-v5-slorber": "^1.0.1",
-        "react-router": "^5.3.3",
-        "react-router-config": "^5.1.1",
-        "react-router-dom": "^5.3.3",
-        "rtl-detect": "^1.0.4",
-        "semver": "^7.3.7",
-        "serve-handler": "^6.1.3",
-        "shelljs": "^0.8.5",
-        "terser-webpack-plugin": "^5.3.3",
-        "tslib": "^2.4.0",
-        "update-notifier": "^5.1.0",
-        "url-loader": "^4.1.1",
-        "wait-on": "^6.0.1",
-        "webpack": "^5.73.0",
-        "webpack-bundle-analyzer": "^4.5.0",
-        "webpack-dev-server": "^4.9.3",
-        "webpack-merge": "^5.8.0",
-        "webpackbar": "^5.0.2"
-      },
-      "bin": {
-        "docusaurus": "bin/docusaurus.mjs"
-      },
-      "engines": {
-        "node": ">=16.14"
-      },
-      "peerDependencies": {
-        "react": "^16.8.4 || ^17.0.0",
-        "react-dom": "^16.8.4 || ^17.0.0"
-      }
-    },
-    "node_modules/@docusaurus/plugin-sitemap/node_modules/@docusaurus/cssnano-preset": {
-      "version": "2.3.1",
-      "resolved": "https://registry.npmjs.org/@docusaurus/cssnano-preset/-/cssnano-preset-2.3.1.tgz",
-      "integrity": "sha512-7mIhAROES6CY1GmCjR4CZkUfjTL6B3u6rKHK0ChQl2d1IevYXq/k/vFgvOrJfcKxiObpMnE9+X6R2Wt1KqxC6w==",
-      "dependencies": {
-        "cssnano-preset-advanced": "^5.3.8",
-        "postcss": "^8.4.14",
-        "postcss-sort-media-queries": "^4.2.1",
-        "tslib": "^2.4.0"
-      },
-      "engines": {
-        "node": ">=16.14"
-      }
-    },
-    "node_modules/@docusaurus/preset-classic": {
-      "version": "2.3.1",
-      "resolved": "https://registry.npmjs.org/@docusaurus/preset-classic/-/preset-classic-2.3.1.tgz",
-      "integrity": "sha512-OQ5W0AHyfdUk0IldwJ3BlnZ1EqoJuu2L2BMhqLbqwNWdkmzmSUvlFLH1Pe7CZSQgB2YUUC/DnmjbPKk/qQD0lQ==",
-      "dependencies": {
-        "@docusaurus/core": "2.3.1",
-        "@docusaurus/plugin-content-blog": "2.3.1",
-        "@docusaurus/plugin-content-docs": "2.3.1",
-        "@docusaurus/plugin-content-pages": "2.3.1",
-        "@docusaurus/plugin-debug": "2.3.1",
-        "@docusaurus/plugin-google-analytics": "2.3.1",
-        "@docusaurus/plugin-google-gtag": "2.3.1",
-        "@docusaurus/plugin-google-tag-manager": "2.3.1",
-        "@docusaurus/plugin-sitemap": "2.3.1",
-        "@docusaurus/theme-classic": "2.3.1",
-        "@docusaurus/theme-common": "2.3.1",
-        "@docusaurus/theme-search-algolia": "2.3.1",
-        "@docusaurus/types": "2.3.1"
-      },
-      "engines": {
-        "node": ">=16.14"
-      },
-      "peerDependencies": {
-        "react": "^16.8.4 || ^17.0.0",
-        "react-dom": "^16.8.4 || ^17.0.0"
-      }
-    },
-    "node_modules/@docusaurus/preset-classic/node_modules/@docusaurus/core": {
-      "version": "2.3.1",
-      "resolved": "https://registry.npmjs.org/@docusaurus/core/-/core-2.3.1.tgz",
-      "integrity": "sha512-0Jd4jtizqnRAr7svWaBbbrCCN8mzBNd2xFLoT/IM7bGfFie5y58oz97KzXliwiLY3zWjqMXjQcuP1a5VgCv2JA==",
-      "dependencies": {
-        "@babel/core": "^7.18.6",
-        "@babel/generator": "^7.18.7",
-        "@babel/plugin-syntax-dynamic-import": "^7.8.3",
-        "@babel/plugin-transform-runtime": "^7.18.6",
-        "@babel/preset-env": "^7.18.6",
-        "@babel/preset-react": "^7.18.6",
-        "@babel/preset-typescript": "^7.18.6",
-        "@babel/runtime": "^7.18.6",
-        "@babel/runtime-corejs3": "^7.18.6",
-        "@babel/traverse": "^7.18.8",
-        "@docusaurus/cssnano-preset": "2.3.1",
-        "@docusaurus/logger": "2.3.1",
-        "@docusaurus/mdx-loader": "2.3.1",
-        "@docusaurus/react-loadable": "5.5.2",
-        "@docusaurus/utils": "2.3.1",
-        "@docusaurus/utils-common": "2.3.1",
-        "@docusaurus/utils-validation": "2.3.1",
-        "@slorber/static-site-generator-webpack-plugin": "^4.0.7",
-        "@svgr/webpack": "^6.2.1",
-        "autoprefixer": "^10.4.7",
-        "babel-loader": "^8.2.5",
-        "babel-plugin-dynamic-import-node": "^2.3.3",
-        "boxen": "^6.2.1",
-        "chalk": "^4.1.2",
-        "chokidar": "^3.5.3",
-        "clean-css": "^5.3.0",
-        "cli-table3": "^0.6.2",
-        "combine-promises": "^1.1.0",
-        "commander": "^5.1.0",
-        "copy-webpack-plugin": "^11.0.0",
-        "core-js": "^3.23.3",
-        "css-loader": "^6.7.1",
-        "css-minimizer-webpack-plugin": "^4.0.0",
-        "cssnano": "^5.1.12",
-        "del": "^6.1.1",
-        "detect-port": "^1.3.0",
-        "escape-html": "^1.0.3",
-        "eta": "^2.0.0",
-        "file-loader": "^6.2.0",
-        "fs-extra": "^10.1.0",
-        "html-minifier-terser": "^6.1.0",
-        "html-tags": "^3.2.0",
-        "html-webpack-plugin": "^5.5.0",
-        "import-fresh": "^3.3.0",
-        "leven": "^3.1.0",
-        "lodash": "^4.17.21",
-        "mini-css-extract-plugin": "^2.6.1",
-        "postcss": "^8.4.14",
-        "postcss-loader": "^7.0.0",
-        "prompts": "^2.4.2",
-        "react-dev-utils": "^12.0.1",
-        "react-helmet-async": "^1.3.0",
-        "react-loadable": "npm:@docusaurus/react-loadable@5.5.2",
-        "react-loadable-ssr-addon-v5-slorber": "^1.0.1",
-        "react-router": "^5.3.3",
-        "react-router-config": "^5.1.1",
-        "react-router-dom": "^5.3.3",
-        "rtl-detect": "^1.0.4",
-        "semver": "^7.3.7",
-        "serve-handler": "^6.1.3",
-        "shelljs": "^0.8.5",
-        "terser-webpack-plugin": "^5.3.3",
-        "tslib": "^2.4.0",
-        "update-notifier": "^5.1.0",
-        "url-loader": "^4.1.1",
-        "wait-on": "^6.0.1",
-        "webpack": "^5.73.0",
-        "webpack-bundle-analyzer": "^4.5.0",
-        "webpack-dev-server": "^4.9.3",
-        "webpack-merge": "^5.8.0",
-        "webpackbar": "^5.0.2"
-      },
-      "bin": {
-        "docusaurus": "bin/docusaurus.mjs"
-      },
-      "engines": {
-        "node": ">=16.14"
-      },
-      "peerDependencies": {
-        "react": "^16.8.4 || ^17.0.0",
-        "react-dom": "^16.8.4 || ^17.0.0"
-      }
-    },
-    "node_modules/@docusaurus/preset-classic/node_modules/@docusaurus/cssnano-preset": {
-      "version": "2.3.1",
-      "resolved": "https://registry.npmjs.org/@docusaurus/cssnano-preset/-/cssnano-preset-2.3.1.tgz",
-      "integrity": "sha512-7mIhAROES6CY1GmCjR4CZkUfjTL6B3u6rKHK0ChQl2d1IevYXq/k/vFgvOrJfcKxiObpMnE9+X6R2Wt1KqxC6w==",
-      "dependencies": {
-        "cssnano-preset-advanced": "^5.3.8",
-        "postcss": "^8.4.14",
-        "postcss-sort-media-queries": "^4.2.1",
-        "tslib": "^2.4.0"
-      },
-      "engines": {
-        "node": ">=16.14"
-      }
-    },
-    "node_modules/@docusaurus/react-loadable": {
-      "version": "5.5.2",
-      "resolved": "https://registry.npmjs.org/@docusaurus/react-loadable/-/react-loadable-5.5.2.tgz",
-      "integrity": "sha512-A3dYjdBGuy0IGT+wyLIGIKLRE+sAk1iNk0f1HjNDysO7u8lhL4N3VEm+FAubmJbAztn94F7MxBTPmnixbiyFdQ==",
-      "dependencies": {
-        "@types/react": "*",
-        "prop-types": "^15.6.2"
-      },
-      "peerDependencies": {
-        "react": "*"
-      }
-    },
-    "node_modules/@docusaurus/theme-classic": {
-      "version": "2.3.1",
-      "resolved": "https://registry.npmjs.org/@docusaurus/theme-classic/-/theme-classic-2.3.1.tgz",
-      "integrity": "sha512-SelSIDvyttb7ZYHj8vEUhqykhAqfOPKk+uP0z85jH72IMC58e7O8DIlcAeBv+CWsLbNIl9/Hcg71X0jazuxJug==",
-      "dependencies": {
-        "@docusaurus/core": "2.3.1",
-        "@docusaurus/mdx-loader": "2.3.1",
-        "@docusaurus/module-type-aliases": "2.3.1",
-        "@docusaurus/plugin-content-blog": "2.3.1",
-        "@docusaurus/plugin-content-docs": "2.3.1",
-        "@docusaurus/plugin-content-pages": "2.3.1",
-        "@docusaurus/theme-common": "2.3.1",
-        "@docusaurus/theme-translations": "2.3.1",
-        "@docusaurus/types": "2.3.1",
-        "@docusaurus/utils": "2.3.1",
-        "@docusaurus/utils-common": "2.3.1",
-        "@docusaurus/utils-validation": "2.3.1",
-        "@mdx-js/react": "^1.6.22",
-        "clsx": "^1.2.1",
-        "copy-text-to-clipboard": "^3.0.1",
-        "infima": "0.2.0-alpha.42",
-        "lodash": "^4.17.21",
-        "nprogress": "^0.2.0",
-        "postcss": "^8.4.14",
-        "prism-react-renderer": "^1.3.5",
-        "prismjs": "^1.28.0",
-        "react-router-dom": "^5.3.3",
-        "rtlcss": "^3.5.0",
-        "tslib": "^2.4.0",
-        "utility-types": "^3.10.0"
-      },
-      "engines": {
-        "node": ">=16.14"
-      },
-      "peerDependencies": {
-        "react": "^16.8.4 || ^17.0.0",
-        "react-dom": "^16.8.4 || ^17.0.0"
-      }
-    },
-    "node_modules/@docusaurus/theme-classic/node_modules/@docusaurus/core": {
-      "version": "2.3.1",
-      "resolved": "https://registry.npmjs.org/@docusaurus/core/-/core-2.3.1.tgz",
-      "integrity": "sha512-0Jd4jtizqnRAr7svWaBbbrCCN8mzBNd2xFLoT/IM7bGfFie5y58oz97KzXliwiLY3zWjqMXjQcuP1a5VgCv2JA==",
-      "dependencies": {
-        "@babel/core": "^7.18.6",
-        "@babel/generator": "^7.18.7",
-        "@babel/plugin-syntax-dynamic-import": "^7.8.3",
-        "@babel/plugin-transform-runtime": "^7.18.6",
-        "@babel/preset-env": "^7.18.6",
-        "@babel/preset-react": "^7.18.6",
-        "@babel/preset-typescript": "^7.18.6",
-        "@babel/runtime": "^7.18.6",
-        "@babel/runtime-corejs3": "^7.18.6",
-        "@babel/traverse": "^7.18.8",
-        "@docusaurus/cssnano-preset": "2.3.1",
-        "@docusaurus/logger": "2.3.1",
-        "@docusaurus/mdx-loader": "2.3.1",
-        "@docusaurus/react-loadable": "5.5.2",
-        "@docusaurus/utils": "2.3.1",
-        "@docusaurus/utils-common": "2.3.1",
-        "@docusaurus/utils-validation": "2.3.1",
-        "@slorber/static-site-generator-webpack-plugin": "^4.0.7",
-        "@svgr/webpack": "^6.2.1",
-        "autoprefixer": "^10.4.7",
-        "babel-loader": "^8.2.5",
-        "babel-plugin-dynamic-import-node": "^2.3.3",
-        "boxen": "^6.2.1",
-        "chalk": "^4.1.2",
-        "chokidar": "^3.5.3",
-        "clean-css": "^5.3.0",
-        "cli-table3": "^0.6.2",
-        "combine-promises": "^1.1.0",
-        "commander": "^5.1.0",
-        "copy-webpack-plugin": "^11.0.0",
-        "core-js": "^3.23.3",
-        "css-loader": "^6.7.1",
-        "css-minimizer-webpack-plugin": "^4.0.0",
-        "cssnano": "^5.1.12",
-        "del": "^6.1.1",
-        "detect-port": "^1.3.0",
-        "escape-html": "^1.0.3",
-        "eta": "^2.0.0",
-        "file-loader": "^6.2.0",
-        "fs-extra": "^10.1.0",
-        "html-minifier-terser": "^6.1.0",
-        "html-tags": "^3.2.0",
-        "html-webpack-plugin": "^5.5.0",
-        "import-fresh": "^3.3.0",
-        "leven": "^3.1.0",
-        "lodash": "^4.17.21",
-        "mini-css-extract-plugin": "^2.6.1",
-        "postcss": "^8.4.14",
-        "postcss-loader": "^7.0.0",
-        "prompts": "^2.4.2",
-        "react-dev-utils": "^12.0.1",
-        "react-helmet-async": "^1.3.0",
-        "react-loadable": "npm:@docusaurus/react-loadable@5.5.2",
-        "react-loadable-ssr-addon-v5-slorber": "^1.0.1",
-        "react-router": "^5.3.3",
-        "react-router-config": "^5.1.1",
-        "react-router-dom": "^5.3.3",
-        "rtl-detect": "^1.0.4",
-        "semver": "^7.3.7",
-        "serve-handler": "^6.1.3",
-        "shelljs": "^0.8.5",
-        "terser-webpack-plugin": "^5.3.3",
-        "tslib": "^2.4.0",
-        "update-notifier": "^5.1.0",
-        "url-loader": "^4.1.1",
-        "wait-on": "^6.0.1",
-        "webpack": "^5.73.0",
-        "webpack-bundle-analyzer": "^4.5.0",
-        "webpack-dev-server": "^4.9.3",
-        "webpack-merge": "^5.8.0",
-        "webpackbar": "^5.0.2"
-      },
-      "bin": {
-        "docusaurus": "bin/docusaurus.mjs"
-      },
-      "engines": {
-        "node": ">=16.14"
-      },
-      "peerDependencies": {
-        "react": "^16.8.4 || ^17.0.0",
-        "react-dom": "^16.8.4 || ^17.0.0"
-      }
-    },
-    "node_modules/@docusaurus/theme-classic/node_modules/@docusaurus/cssnano-preset": {
-      "version": "2.3.1",
-      "resolved": "https://registry.npmjs.org/@docusaurus/cssnano-preset/-/cssnano-preset-2.3.1.tgz",
-      "integrity": "sha512-7mIhAROES6CY1GmCjR4CZkUfjTL6B3u6rKHK0ChQl2d1IevYXq/k/vFgvOrJfcKxiObpMnE9+X6R2Wt1KqxC6w==",
-      "dependencies": {
-        "cssnano-preset-advanced": "^5.3.8",
-        "postcss": "^8.4.14",
-        "postcss-sort-media-queries": "^4.2.1",
-        "tslib": "^2.4.0"
-      },
-      "engines": {
-        "node": ">=16.14"
-      }
-    },
-    "node_modules/@docusaurus/theme-classic/node_modules/@docusaurus/module-type-aliases": {
-      "version": "2.3.1",
-      "resolved": "https://registry.npmjs.org/@docusaurus/module-type-aliases/-/module-type-aliases-2.3.1.tgz",
-      "integrity": "sha512-6KkxfAVOJqIUynTRb/tphYCl+co3cP0PlHiMDbi+SzmYxMdgIrwYqH9yAnGSDoN6Jk2ZE/JY/Azs/8LPgKP48A==",
-      "dependencies": {
-        "@docusaurus/react-loadable": "5.5.2",
-        "@docusaurus/types": "2.3.1",
-        "@types/history": "^4.7.11",
-        "@types/react": "*",
-        "@types/react-router-config": "*",
-        "@types/react-router-dom": "*",
-        "react-helmet-async": "*",
-        "react-loadable": "npm:@docusaurus/react-loadable@5.5.2"
-      },
-      "peerDependencies": {
-        "react": "*",
-        "react-dom": "*"
-      }
-    },
-    "node_modules/@docusaurus/theme-common": {
-      "version": "2.3.1",
-      "resolved": "https://registry.npmjs.org/@docusaurus/theme-common/-/theme-common-2.3.1.tgz",
-      "integrity": "sha512-RYmYl2OR2biO+yhmW1aS5FyEvnrItPINa+0U2dMxcHpah8reSCjQ9eJGRmAgkZFchV1+aIQzXOI1K7LCW38O0g==",
-      "dependencies": {
-        "@docusaurus/mdx-loader": "2.3.1",
-        "@docusaurus/module-type-aliases": "2.3.1",
-        "@docusaurus/plugin-content-blog": "2.3.1",
-        "@docusaurus/plugin-content-docs": "2.3.1",
-        "@docusaurus/plugin-content-pages": "2.3.1",
-        "@docusaurus/utils": "2.3.1",
-        "@types/history": "^4.7.11",
-        "@types/react": "*",
-        "@types/react-router-config": "*",
-        "clsx": "^1.2.1",
-        "parse-numeric-range": "^1.3.0",
-        "prism-react-renderer": "^1.3.5",
-        "tslib": "^2.4.0",
-        "use-sync-external-store": "^1.2.0",
-        "utility-types": "^3.10.0"
-      },
-      "engines": {
-        "node": ">=16.14"
-      },
-      "peerDependencies": {
-        "react": "^16.8.4 || ^17.0.0",
-        "react-dom": "^16.8.4 || ^17.0.0"
-      }
-    },
-    "node_modules/@docusaurus/theme-common/node_modules/@docusaurus/module-type-aliases": {
-      "version": "2.3.1",
-      "resolved": "https://registry.npmjs.org/@docusaurus/module-type-aliases/-/module-type-aliases-2.3.1.tgz",
-      "integrity": "sha512-6KkxfAVOJqIUynTRb/tphYCl+co3cP0PlHiMDbi+SzmYxMdgIrwYqH9yAnGSDoN6Jk2ZE/JY/Azs/8LPgKP48A==",
-      "dependencies": {
-        "@docusaurus/react-loadable": "5.5.2",
-        "@docusaurus/types": "2.3.1",
-        "@types/history": "^4.7.11",
-        "@types/react": "*",
-        "@types/react-router-config": "*",
-        "@types/react-router-dom": "*",
-        "react-helmet-async": "*",
-        "react-loadable": "npm:@docusaurus/react-loadable@5.5.2"
-      },
-      "peerDependencies": {
-        "react": "*",
-        "react-dom": "*"
-      }
-    },
-    "node_modules/@docusaurus/theme-search-algolia": {
-      "version": "2.3.1",
-      "resolved": "https://registry.npmjs.org/@docusaurus/theme-search-algolia/-/theme-search-algolia-2.3.1.tgz",
-      "integrity": "sha512-JdHaRqRuH1X++g5fEMLnq7OtULSGQdrs9AbhcWRQ428ZB8/HOiaN6mj3hzHvcD3DFgu7koIVtWPQnvnN7iwzHA==",
-      "dependencies": {
-        "@docsearch/react": "^3.1.1",
-        "@docusaurus/core": "2.3.1",
-        "@docusaurus/logger": "2.3.1",
-        "@docusaurus/plugin-content-docs": "2.3.1",
-        "@docusaurus/theme-common": "2.3.1",
-        "@docusaurus/theme-translations": "2.3.1",
-        "@docusaurus/utils": "2.3.1",
-        "@docusaurus/utils-validation": "2.3.1",
-        "algoliasearch": "^4.13.1",
-        "algoliasearch-helper": "^3.10.0",
-        "clsx": "^1.2.1",
-        "eta": "^2.0.0",
-        "fs-extra": "^10.1.0",
-        "lodash": "^4.17.21",
-        "tslib": "^2.4.0",
-        "utility-types": "^3.10.0"
-      },
-      "engines": {
-        "node": ">=16.14"
-      },
-      "peerDependencies": {
-        "react": "^16.8.4 || ^17.0.0",
-        "react-dom": "^16.8.4 || ^17.0.0"
-      }
-    },
-    "node_modules/@docusaurus/theme-search-algolia/node_modules/@docusaurus/core": {
-      "version": "2.3.1",
-      "resolved": "https://registry.npmjs.org/@docusaurus/core/-/core-2.3.1.tgz",
-      "integrity": "sha512-0Jd4jtizqnRAr7svWaBbbrCCN8mzBNd2xFLoT/IM7bGfFie5y58oz97KzXliwiLY3zWjqMXjQcuP1a5VgCv2JA==",
-      "dependencies": {
-        "@babel/core": "^7.18.6",
-        "@babel/generator": "^7.18.7",
-        "@babel/plugin-syntax-dynamic-import": "^7.8.3",
-        "@babel/plugin-transform-runtime": "^7.18.6",
-        "@babel/preset-env": "^7.18.6",
-        "@babel/preset-react": "^7.18.6",
-        "@babel/preset-typescript": "^7.18.6",
-        "@babel/runtime": "^7.18.6",
-        "@babel/runtime-corejs3": "^7.18.6",
-        "@babel/traverse": "^7.18.8",
-        "@docusaurus/cssnano-preset": "2.3.1",
-        "@docusaurus/logger": "2.3.1",
-        "@docusaurus/mdx-loader": "2.3.1",
-        "@docusaurus/react-loadable": "5.5.2",
-        "@docusaurus/utils": "2.3.1",
-        "@docusaurus/utils-common": "2.3.1",
-        "@docusaurus/utils-validation": "2.3.1",
-        "@slorber/static-site-generator-webpack-plugin": "^4.0.7",
-        "@svgr/webpack": "^6.2.1",
-        "autoprefixer": "^10.4.7",
-        "babel-loader": "^8.2.5",
-        "babel-plugin-dynamic-import-node": "^2.3.3",
-        "boxen": "^6.2.1",
-        "chalk": "^4.1.2",
-        "chokidar": "^3.5.3",
-        "clean-css": "^5.3.0",
-        "cli-table3": "^0.6.2",
-        "combine-promises": "^1.1.0",
-        "commander": "^5.1.0",
-        "copy-webpack-plugin": "^11.0.0",
-        "core-js": "^3.23.3",
-        "css-loader": "^6.7.1",
-        "css-minimizer-webpack-plugin": "^4.0.0",
-        "cssnano": "^5.1.12",
-        "del": "^6.1.1",
-        "detect-port": "^1.3.0",
-        "escape-html": "^1.0.3",
-        "eta": "^2.0.0",
-        "file-loader": "^6.2.0",
-        "fs-extra": "^10.1.0",
-        "html-minifier-terser": "^6.1.0",
-        "html-tags": "^3.2.0",
-        "html-webpack-plugin": "^5.5.0",
-        "import-fresh": "^3.3.0",
-        "leven": "^3.1.0",
-        "lodash": "^4.17.21",
-        "mini-css-extract-plugin": "^2.6.1",
-        "postcss": "^8.4.14",
-        "postcss-loader": "^7.0.0",
-        "prompts": "^2.4.2",
-        "react-dev-utils": "^12.0.1",
-        "react-helmet-async": "^1.3.0",
-        "react-loadable": "npm:@docusaurus/react-loadable@5.5.2",
-        "react-loadable-ssr-addon-v5-slorber": "^1.0.1",
-        "react-router": "^5.3.3",
-        "react-router-config": "^5.1.1",
-        "react-router-dom": "^5.3.3",
-        "rtl-detect": "^1.0.4",
-        "semver": "^7.3.7",
-        "serve-handler": "^6.1.3",
-        "shelljs": "^0.8.5",
-        "terser-webpack-plugin": "^5.3.3",
-        "tslib": "^2.4.0",
-        "update-notifier": "^5.1.0",
-        "url-loader": "^4.1.1",
-        "wait-on": "^6.0.1",
-        "webpack": "^5.73.0",
-        "webpack-bundle-analyzer": "^4.5.0",
-        "webpack-dev-server": "^4.9.3",
-        "webpack-merge": "^5.8.0",
-        "webpackbar": "^5.0.2"
-      },
-      "bin": {
-        "docusaurus": "bin/docusaurus.mjs"
-      },
-      "engines": {
-        "node": ">=16.14"
-      },
-      "peerDependencies": {
-        "react": "^16.8.4 || ^17.0.0",
-        "react-dom": "^16.8.4 || ^17.0.0"
-      }
-    },
-    "node_modules/@docusaurus/theme-search-algolia/node_modules/@docusaurus/cssnano-preset": {
-      "version": "2.3.1",
-      "resolved": "https://registry.npmjs.org/@docusaurus/cssnano-preset/-/cssnano-preset-2.3.1.tgz",
-      "integrity": "sha512-7mIhAROES6CY1GmCjR4CZkUfjTL6B3u6rKHK0ChQl2d1IevYXq/k/vFgvOrJfcKxiObpMnE9+X6R2Wt1KqxC6w==",
-      "dependencies": {
-        "cssnano-preset-advanced": "^5.3.8",
-        "postcss": "^8.4.14",
-        "postcss-sort-media-queries": "^4.2.1",
-        "tslib": "^2.4.0"
-      },
-      "engines": {
-        "node": ">=16.14"
-      }
-    },
-    "node_modules/@docusaurus/theme-translations": {
-      "version": "2.3.1",
-      "resolved": "https://registry.npmjs.org/@docusaurus/theme-translations/-/theme-translations-2.3.1.tgz",
-      "integrity": "sha512-BsBZzAewJabVhoGG1Ij2u4pMS3MPW6gZ6sS4pc+Y7czevRpzxoFNJXRtQDVGe7mOpv/MmRmqg4owDK+lcOTCVQ==",
-      "dependencies": {
-        "fs-extra": "^10.1.0",
-        "tslib": "^2.4.0"
-      },
-      "engines": {
-        "node": ">=16.14"
-      }
-    },
-    "node_modules/@docusaurus/types": {
-      "version": "2.3.1",
-      "resolved": "https://registry.npmjs.org/@docusaurus/types/-/types-2.3.1.tgz",
-      "integrity": "sha512-PREbIRhTaNNY042qmfSE372Jb7djZt+oVTZkoqHJ8eff8vOIc2zqqDqBVc5BhOfpZGPTrE078yy/torUEZy08A==",
-      "dependencies": {
-        "@types/history": "^4.7.11",
-        "@types/react": "*",
-        "commander": "^5.1.0",
-        "joi": "^17.6.0",
-        "react-helmet-async": "^1.3.0",
-        "utility-types": "^3.10.0",
-        "webpack": "^5.73.0",
-        "webpack-merge": "^5.8.0"
-      },
-      "peerDependencies": {
-        "react": "^16.8.4 || ^17.0.0",
-        "react-dom": "^16.8.4 || ^17.0.0"
-      }
-    },
-    "node_modules/@docusaurus/utils": {
-      "version": "2.3.1",
-      "resolved": "https://registry.npmjs.org/@docusaurus/utils/-/utils-2.3.1.tgz",
-      "integrity": "sha512-9WcQROCV0MmrpOQDXDGhtGMd52DHpSFbKLfkyaYumzbTstrbA5pPOtiGtxK1nqUHkiIv8UwexS54p0Vod2I1lg==",
-      "dependencies": {
-        "@docusaurus/logger": "2.3.1",
-        "@svgr/webpack": "^6.2.1",
-        "escape-string-regexp": "^4.0.0",
-        "file-loader": "^6.2.0",
-        "fs-extra": "^10.1.0",
-        "github-slugger": "^1.4.0",
-        "globby": "^11.1.0",
-        "gray-matter": "^4.0.3",
-        "js-yaml": "^4.1.0",
-        "lodash": "^4.17.21",
-        "micromatch": "^4.0.5",
-        "resolve-pathname": "^3.0.0",
-        "shelljs": "^0.8.5",
-        "tslib": "^2.4.0",
-        "url-loader": "^4.1.1",
-        "webpack": "^5.73.0"
-      },
-      "engines": {
-        "node": ">=16.14"
-      },
-      "peerDependencies": {
-        "@docusaurus/types": "*"
-      },
-      "peerDependenciesMeta": {
-        "@docusaurus/types": {
-          "optional": true
-        }
-      }
-    },
-    "node_modules/@docusaurus/utils-common": {
-      "version": "2.3.1",
-      "resolved": "https://registry.npmjs.org/@docusaurus/utils-common/-/utils-common-2.3.1.tgz",
-      "integrity": "sha512-pVlRpXkdNcxmKNxAaB1ya2hfCEvVsLDp2joeM6K6uv55Oc5nVIqgyYSgSNKZyMdw66NnvMfsu0RBylcwZQKo9A==",
-      "dependencies": {
-        "tslib": "^2.4.0"
-      },
-      "engines": {
-        "node": ">=16.14"
-      },
-      "peerDependencies": {
-        "@docusaurus/types": "*"
-      },
-      "peerDependenciesMeta": {
-        "@docusaurus/types": {
-          "optional": true
-        }
-      }
-    },
-    "node_modules/@docusaurus/utils-validation": {
-      "version": "2.3.1",
-      "resolved": "https://registry.npmjs.org/@docusaurus/utils-validation/-/utils-validation-2.3.1.tgz",
-      "integrity": "sha512-7n0208IG3k1HVTByMHlZoIDjjOFC8sbViHVXJx0r3Q+3Ezrx+VQ1RZ/zjNn6lT+QBCRCXlnlaoJ8ug4HIVgQ3w==",
-      "dependencies": {
-        "@docusaurus/logger": "2.3.1",
-        "@docusaurus/utils": "2.3.1",
         "joi": "^17.6.0",
         "js-yaml": "^4.1.0",
         "tslib": "^2.4.0"
@@ -5030,30 +3720,30 @@
       }
     },
     "node_modules/algoliasearch": {
-      "version": "4.14.3",
-      "resolved": "https://registry.npmjs.org/algoliasearch/-/algoliasearch-4.14.3.tgz",
-      "integrity": "sha512-GZTEuxzfWbP/vr7ZJfGzIl8fOsoxN916Z6FY2Egc9q2TmZ6hvq5KfAxY89pPW01oW/2HDEKA8d30f9iAH9eXYg==",
+      "version": "4.16.0",
+      "resolved": "https://registry.npmjs.org/algoliasearch/-/algoliasearch-4.16.0.tgz",
+      "integrity": "sha512-HAjKJ6bBblaXqO4dYygF4qx251GuJ6zCZt+qbJ+kU7sOC+yc84pawEjVpJByh+cGP2APFCsao2Giz50cDlKNPA==",
       "dependencies": {
-        "@algolia/cache-browser-local-storage": "4.14.3",
-        "@algolia/cache-common": "4.14.3",
-        "@algolia/cache-in-memory": "4.14.3",
-        "@algolia/client-account": "4.14.3",
-        "@algolia/client-analytics": "4.14.3",
-        "@algolia/client-common": "4.14.3",
-        "@algolia/client-personalization": "4.14.3",
-        "@algolia/client-search": "4.14.3",
-        "@algolia/logger-common": "4.14.3",
-        "@algolia/logger-console": "4.14.3",
-        "@algolia/requester-browser-xhr": "4.14.3",
-        "@algolia/requester-common": "4.14.3",
-        "@algolia/requester-node-http": "4.14.3",
-        "@algolia/transporter": "4.14.3"
+        "@algolia/cache-browser-local-storage": "4.16.0",
+        "@algolia/cache-common": "4.16.0",
+        "@algolia/cache-in-memory": "4.16.0",
+        "@algolia/client-account": "4.16.0",
+        "@algolia/client-analytics": "4.16.0",
+        "@algolia/client-common": "4.16.0",
+        "@algolia/client-personalization": "4.16.0",
+        "@algolia/client-search": "4.16.0",
+        "@algolia/logger-common": "4.16.0",
+        "@algolia/logger-console": "4.16.0",
+        "@algolia/requester-browser-xhr": "4.16.0",
+        "@algolia/requester-common": "4.16.0",
+        "@algolia/requester-node-http": "4.16.0",
+        "@algolia/transporter": "4.16.0"
       }
     },
     "node_modules/algoliasearch-helper": {
-      "version": "3.11.3",
-      "resolved": "https://registry.npmjs.org/algoliasearch-helper/-/algoliasearch-helper-3.11.3.tgz",
-      "integrity": "sha512-TbaEvLwiuGygHQIB8y+OsJKQQ40+JKUua5B91X66tMUHyyhbNHvqyr0lqd3wCoyKx7WybyQrC0WJvzoIeh24Aw==",
+      "version": "3.12.0",
+      "resolved": "https://registry.npmjs.org/algoliasearch-helper/-/algoliasearch-helper-3.12.0.tgz",
+      "integrity": "sha512-/j1U3PEwdan0n6P/QqSnSpNSLC5+cEMvyljd5CnmNmUjDlGrys+vFEOwjVEnqELIiAGMHEA/Nl3CiKVFBUYqyQ==",
       "dependencies": {
         "@algolia/events": "^4.0.1"
       },
@@ -6066,9 +4756,9 @@
       "integrity": "sha512-QADzlaHc8icV8I7vbaJXJwod9HWYp8uCqf1xa4OfNu1T7JVxQIrUgOWtHdNDtPiywmFbiS12VjotIXLrKM3orQ=="
     },
     "node_modules/copy-text-to-clipboard": {
-      "version": "3.0.1",
-      "resolved": "https://registry.npmjs.org/copy-text-to-clipboard/-/copy-text-to-clipboard-3.0.1.tgz",
-      "integrity": "sha512-rvVsHrpFcL4F2P8ihsoLdFHmd404+CMg71S756oRSeQgqk51U3kicGdnvfkrxva0xXH92SjGS62B0XIJsbh+9Q==",
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/copy-text-to-clipboard/-/copy-text-to-clipboard-3.1.0.tgz",
+      "integrity": "sha512-PFM6BnjLnOON/lB3ta/Jg7Ywsv+l9kQGD4TWDCSlRBGmqnnTM5MrDkhAFgw+8HZt0wW6Q2BBE4cmy9sq+s9Qng==",
       "engines": {
         "node": ">=12"
       },
@@ -7448,9 +6138,9 @@
       }
     },
     "node_modules/flux": {
-      "version": "4.0.3",
-      "resolved": "https://registry.npmjs.org/flux/-/flux-4.0.3.tgz",
-      "integrity": "sha512-yKAbrp7JhZhj6uiT1FTuVMlIAT1J4jqEyBpFApi1kxpGZCvacMVc/t1pMQyotqHhAgvoE3bNvAykhCo2CLjnYw==",
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/flux/-/flux-4.0.4.tgz",
+      "integrity": "sha512-NCj3XlayA2UsapRpM7va6wU1+9rE5FIL7qoMcmxWHRzbp0yujihMBm9BBHZ1MDIk5h5o2Bl6eGiCe8rYELAmYw==",
       "dependencies": {
         "fbemitter": "^3.0.0",
         "fbjs": "^3.0.1"
@@ -8173,9 +6863,9 @@
       }
     },
     "node_modules/htmlparser2": {
-      "version": "8.0.1",
-      "resolved": "https://registry.npmjs.org/htmlparser2/-/htmlparser2-8.0.1.tgz",
-      "integrity": "sha512-4lVbmc1diZC7GUJQtRQ5yBAeUCL1exyMwmForWkRLnwyzWBFxN633SALPMGYaWZvKe9j1pRZJpauvmxENSp/EA==",
+      "version": "8.0.2",
+      "resolved": "https://registry.npmjs.org/htmlparser2/-/htmlparser2-8.0.2.tgz",
+      "integrity": "sha512-GYdjWKDkbRLkZ5geuHs5NY1puJ+PXwP7+fHPRz06Eirsb9ugf6d8kkXav6ADhcODhFFPMIXyxkxSuMf3D6NCFA==",
       "funding": [
         "https://github.com/fb55/htmlparser2?sponsor=1",
         {
@@ -8185,9 +6875,9 @@
       ],
       "dependencies": {
         "domelementtype": "^2.3.0",
-        "domhandler": "^5.0.2",
+        "domhandler": "^5.0.3",
         "domutils": "^3.0.1",
-        "entities": "^4.3.0"
+        "entities": "^4.4.0"
       }
     },
     "node_modules/http-cache-semantics": {
@@ -8368,9 +7058,9 @@
       }
     },
     "node_modules/infima": {
-      "version": "0.2.0-alpha.42",
-      "resolved": "https://registry.npmjs.org/infima/-/infima-0.2.0-alpha.42.tgz",
-      "integrity": "sha512-ift8OXNbQQwtbIt6z16KnSWP7uJ/SysSMFI4F87MNRTicypfl4Pv3E2OGVv6N3nSZFJvA8imYulCBS64iyHYww==",
+      "version": "0.2.0-alpha.43",
+      "resolved": "https://registry.npmjs.org/infima/-/infima-0.2.0-alpha.43.tgz",
+      "integrity": "sha512-2uw57LvUqW0rK/SWYnd/2rRfxNA5DDNOh33jxF7fy46VWoNhGxiUQyVZHbBMjQ33mQem0cjdDVwgWVAmlRfgyQ==",
       "engines": {
         "node": ">=12"
       }
@@ -11041,11 +9731,11 @@
       }
     },
     "node_modules/react-textarea-autosize": {
-      "version": "8.4.0",
-      "resolved": "https://registry.npmjs.org/react-textarea-autosize/-/react-textarea-autosize-8.4.0.tgz",
-      "integrity": "sha512-YrTFaEHLgJsi8sJVYHBzYn+mkP3prGkmP2DKb/tm0t7CLJY5t1Rxix8070LAKb0wby7bl/lf2EeHkuMihMZMwQ==",
+      "version": "8.4.1",
+      "resolved": "https://registry.npmjs.org/react-textarea-autosize/-/react-textarea-autosize-8.4.1.tgz",
+      "integrity": "sha512-aD2C+qK6QypknC+lCMzteOdIjoMbNlgSFmJjCV+DrfTPwp59i/it9mMNf2HDzvRjQgKAyBDPyLJhcrzElf2U4Q==",
       "dependencies": {
-        "@babel/runtime": "^7.10.2",
+        "@babel/runtime": "^7.20.13",
         "use-composed-ref": "^1.3.0",
         "use-latest": "^1.2.1"
       },
@@ -11162,9 +9852,9 @@
       }
     },
     "node_modules/regenerator-runtime": {
-      "version": "0.13.9",
-      "resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.13.9.tgz",
-      "integrity": "sha512-p3VT+cOEgxFsRRA9X4lkI1E+k2/CtnKtU4gcxyaCUreilL/vqI6CdZ3wxVUx3UOUg+gnUOQQcRI7BmSI656MYA=="
+      "version": "0.13.11",
+      "resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.13.11.tgz",
+      "integrity": "sha512-kY1AZVr2Ra+t+piVaJ4gxaFaReZVH40AKNo7UCX6W+dEwBo/2oZJzqfuN1qLq1oL45o56cPaTXELwrTh8Fpggg=="
     },
     "node_modules/regenerator-transform": {
       "version": "0.15.0",
@@ -12744,9 +11434,9 @@
       }
     },
     "node_modules/ua-parser-js": {
-      "version": "0.7.33",
-      "resolved": "https://registry.npmjs.org/ua-parser-js/-/ua-parser-js-0.7.33.tgz",
-      "integrity": "sha512-s8ax/CeZdK9R/56Sui0WM6y9OFREJarMRHqLB2EwkovemBxNQ+Bqu8GAsUnVcXKgphb++ghr/B2BZx4mahujPw==",
+      "version": "0.7.34",
+      "resolved": "https://registry.npmjs.org/ua-parser-js/-/ua-parser-js-0.7.34.tgz",
+      "integrity": "sha512-cJMeh/eOILyGu0ejgTKB95yKT3zOenSe9UGE3vj6WfiOwgGYnmATUsnDixMFvdU+rNMvWih83hrUP8VwhF9yXQ==",
       "funding": [
         {
           "type": "opencollective",
@@ -13968,74 +12658,74 @@
       "integrity": "sha512-2VGCk7I9tA9Ge73Km99+Qg87w0wzW4tgUruvWAn/gfey1ZXgmxZtyIRBebk35R1O8TbK77wujVtCnpsGpRy1kg=="
     },
     "@algolia/cache-browser-local-storage": {
-      "version": "4.14.3",
-      "resolved": "https://registry.npmjs.org/@algolia/cache-browser-local-storage/-/cache-browser-local-storage-4.14.3.tgz",
-      "integrity": "sha512-hWH1yCxgG3+R/xZIscmUrWAIBnmBFHH5j30fY/+aPkEZWt90wYILfAHIOZ1/Wxhho5SkPfwFmT7ooX2d9JeQBw==",
+      "version": "4.16.0",
+      "resolved": "https://registry.npmjs.org/@algolia/cache-browser-local-storage/-/cache-browser-local-storage-4.16.0.tgz",
+      "integrity": "sha512-jVrk0YB3tjOhD5/lhBtYCVCeLjZmVpf2kdi4puApofytf/R0scjWz0GdozlW4HhU+Prxmt/c9ge4QFjtv5OAzQ==",
       "requires": {
-        "@algolia/cache-common": "4.14.3"
+        "@algolia/cache-common": "4.16.0"
       }
     },
     "@algolia/cache-common": {
-      "version": "4.14.3",
-      "resolved": "https://registry.npmjs.org/@algolia/cache-common/-/cache-common-4.14.3.tgz",
-      "integrity": "sha512-oZJofOoD9FQOwiGTzyRnmzvh3ZP8WVTNPBLH5xU5JNF7drDbRT0ocVT0h/xB2rPHYzOeXRrLaQQBwRT/CKom0Q=="
+      "version": "4.16.0",
+      "resolved": "https://registry.npmjs.org/@algolia/cache-common/-/cache-common-4.16.0.tgz",
+      "integrity": "sha512-4iHjkSYQYw46pITrNQgXXhvUmcekI8INz1m+SzmqLX8jexSSy4Ky4zfGhZzhhhLHXUP3+x/PK/c0qPjxEvRwKQ=="
     },
     "@algolia/cache-in-memory": {
-      "version": "4.14.3",
-      "resolved": "https://registry.npmjs.org/@algolia/cache-in-memory/-/cache-in-memory-4.14.3.tgz",
-      "integrity": "sha512-ES0hHQnzWjeioLQf5Nq+x1AWdZJ50znNPSH3puB/Y4Xsg4Av1bvLmTJe7SY2uqONaeMTvL0OaVcoVtQgJVw0vg==",
+      "version": "4.16.0",
+      "resolved": "https://registry.npmjs.org/@algolia/cache-in-memory/-/cache-in-memory-4.16.0.tgz",
+      "integrity": "sha512-p7RYykvA6Ip6QENxrh99nOD77otVh1sJRivcgcVpnjoZb5sIN3t33eUY1DpB9QSBizcrW+qk19rNkdnZ43a+PQ==",
       "requires": {
-        "@algolia/cache-common": "4.14.3"
+        "@algolia/cache-common": "4.16.0"
       }
     },
     "@algolia/client-account": {
-      "version": "4.14.3",
-      "resolved": "https://registry.npmjs.org/@algolia/client-account/-/client-account-4.14.3.tgz",
-      "integrity": "sha512-PBcPb0+f5Xbh5UfLZNx2Ow589OdP8WYjB4CnvupfYBrl9JyC1sdH4jcq/ri8osO/mCZYjZrQsKAPIqW/gQmizQ==",
+      "version": "4.16.0",
+      "resolved": "https://registry.npmjs.org/@algolia/client-account/-/client-account-4.16.0.tgz",
+      "integrity": "sha512-eydcfpdIyuWoKgUSz5iZ/L0wE/Wl7958kACkvTHLDNXvK/b8Z1zypoJavh6/km1ZNQmFpeYS2jrmq0kUSFn02w==",
       "requires": {
-        "@algolia/client-common": "4.14.3",
-        "@algolia/client-search": "4.14.3",
-        "@algolia/transporter": "4.14.3"
+        "@algolia/client-common": "4.16.0",
+        "@algolia/client-search": "4.16.0",
+        "@algolia/transporter": "4.16.0"
       }
     },
     "@algolia/client-analytics": {
-      "version": "4.14.3",
-      "resolved": "https://registry.npmjs.org/@algolia/client-analytics/-/client-analytics-4.14.3.tgz",
-      "integrity": "sha512-eAwQq0Hb/aauv9NhCH5Dp3Nm29oFx28sayFN2fdOWemwSeJHIl7TmcsxVlRsO50fsD8CtPcDhtGeD3AIFLNvqw==",
+      "version": "4.16.0",
+      "resolved": "https://registry.npmjs.org/@algolia/client-analytics/-/client-analytics-4.16.0.tgz",
+      "integrity": "sha512-cONWXH3BfilgdlCofUm492bJRWtpBLVW/hsUlfoFtiX1u05xoBP7qeiDwh9RR+4pSLHLodYkHAf5U4honQ55Qg==",
       "requires": {
-        "@algolia/client-common": "4.14.3",
-        "@algolia/client-search": "4.14.3",
-        "@algolia/requester-common": "4.14.3",
-        "@algolia/transporter": "4.14.3"
+        "@algolia/client-common": "4.16.0",
+        "@algolia/client-search": "4.16.0",
+        "@algolia/requester-common": "4.16.0",
+        "@algolia/transporter": "4.16.0"
       }
     },
     "@algolia/client-common": {
-      "version": "4.14.3",
-      "resolved": "https://registry.npmjs.org/@algolia/client-common/-/client-common-4.14.3.tgz",
-      "integrity": "sha512-jkPPDZdi63IK64Yg4WccdCsAP4pHxSkr4usplkUZM5C1l1oEpZXsy2c579LQ0rvwCs5JFmwfNG4ahOszidfWPw==",
+      "version": "4.16.0",
+      "resolved": "https://registry.npmjs.org/@algolia/client-common/-/client-common-4.16.0.tgz",
+      "integrity": "sha512-QVdR4019ukBH6f5lFr27W60trRxQF1SfS1qo0IP6gjsKhXhUVJuHxOCA6ArF87jrNkeuHEoRoDU+GlvaecNo8g==",
       "requires": {
-        "@algolia/requester-common": "4.14.3",
-        "@algolia/transporter": "4.14.3"
+        "@algolia/requester-common": "4.16.0",
+        "@algolia/transporter": "4.16.0"
       }
     },
     "@algolia/client-personalization": {
-      "version": "4.14.3",
-      "resolved": "https://registry.npmjs.org/@algolia/client-personalization/-/client-personalization-4.14.3.tgz",
-      "integrity": "sha512-UCX1MtkVNgaOL9f0e22x6tC9e2H3unZQlSUdnVaSKpZ+hdSChXGaRjp2UIT7pxmPqNCyv51F597KEX5WT60jNg==",
+      "version": "4.16.0",
+      "resolved": "https://registry.npmjs.org/@algolia/client-personalization/-/client-personalization-4.16.0.tgz",
+      "integrity": "sha512-irtLafssDGPuhYqIwxqOxiWlVYvrsBD+EMA1P9VJtkKi3vSNBxiWeQ0f0Tn53cUNdSRNEssfoEH84JL97SV2SQ==",
       "requires": {
-        "@algolia/client-common": "4.14.3",
-        "@algolia/requester-common": "4.14.3",
-        "@algolia/transporter": "4.14.3"
+        "@algolia/client-common": "4.16.0",
+        "@algolia/requester-common": "4.16.0",
+        "@algolia/transporter": "4.16.0"
       }
     },
     "@algolia/client-search": {
-      "version": "4.14.3",
-      "resolved": "https://registry.npmjs.org/@algolia/client-search/-/client-search-4.14.3.tgz",
-      "integrity": "sha512-I2U7xBx5OPFdPLA8AXKUPPxGY3HDxZ4r7+mlZ8ZpLbI8/ri6fnu6B4z3wcL7sgHhDYMwnAE8Xr0AB0h3Hnkp4A==",
+      "version": "4.16.0",
+      "resolved": "https://registry.npmjs.org/@algolia/client-search/-/client-search-4.16.0.tgz",
+      "integrity": "sha512-xsfrAE1jO/JDh1wFrRz+alVyW+aA6qnkzmbWWWZWEgVF3EaFqzIf9r1l/aDtDdBtNTNhX9H3Lg31+BRtd5izQA==",
       "requires": {
-        "@algolia/client-common": "4.14.3",
-        "@algolia/requester-common": "4.14.3",
-        "@algolia/transporter": "4.14.3"
+        "@algolia/client-common": "4.16.0",
+        "@algolia/requester-common": "4.16.0",
+        "@algolia/transporter": "4.16.0"
       }
     },
     "@algolia/events": {
@@ -14044,47 +12734,47 @@
       "integrity": "sha512-FQzvOCgoFXAbf5Y6mYozw2aj5KCJoA3m4heImceldzPSMbdyS4atVjJzXKMsfX3wnZTFYwkkt8/z8UesLHlSBQ=="
     },
     "@algolia/logger-common": {
-      "version": "4.14.3",
-      "resolved": "https://registry.npmjs.org/@algolia/logger-common/-/logger-common-4.14.3.tgz",
-      "integrity": "sha512-kUEAZaBt/J3RjYi8MEBT2QEexJR2kAE2mtLmezsmqMQZTV502TkHCxYzTwY2dE7OKcUTxi4OFlMuS4GId9CWPw=="
+      "version": "4.16.0",
+      "resolved": "https://registry.npmjs.org/@algolia/logger-common/-/logger-common-4.16.0.tgz",
+      "integrity": "sha512-U9H8uCzSDuePJmbnjjTX21aPDRU6x74Tdq3dJmdYu2+pISx02UeBJm4kSgc9RW5jcR5j35G9gnjHY9Q3ngWbyQ=="
     },
     "@algolia/logger-console": {
-      "version": "4.14.3",
-      "resolved": "https://registry.npmjs.org/@algolia/logger-console/-/logger-console-4.14.3.tgz",
-      "integrity": "sha512-ZWqAlUITktiMN2EiFpQIFCJS10N96A++yrexqC2Z+3hgF/JcKrOxOdT4nSCQoEPvU4Ki9QKbpzbebRDemZt/hw==",
+      "version": "4.16.0",
+      "resolved": "https://registry.npmjs.org/@algolia/logger-console/-/logger-console-4.16.0.tgz",
+      "integrity": "sha512-+qymusiM+lPZKrkf0tDjCQA158eEJO2IU+Nr/sJ9TFyI/xkFPjNPzw/Qbc8Iy/xcOXGlc6eMgmyjtVQqAWq6UA==",
       "requires": {
-        "@algolia/logger-common": "4.14.3"
+        "@algolia/logger-common": "4.16.0"
       }
     },
     "@algolia/requester-browser-xhr": {
-      "version": "4.14.3",
-      "resolved": "https://registry.npmjs.org/@algolia/requester-browser-xhr/-/requester-browser-xhr-4.14.3.tgz",
-      "integrity": "sha512-AZeg2T08WLUPvDncl2XLX2O67W5wIO8MNaT7z5ii5LgBTuk/rU4CikTjCe2xsUleIZeFl++QrPAi4Bdxws6r/Q==",
+      "version": "4.16.0",
+      "resolved": "https://registry.npmjs.org/@algolia/requester-browser-xhr/-/requester-browser-xhr-4.16.0.tgz",
+      "integrity": "sha512-gK+kvs6LHl/PaOJfDuwjkopNbG1djzFLsVBklGBsSU6h6VjFkxIpo6Qq80IK14p9cplYZfhfaL12va6Q9p3KVQ==",
       "requires": {
-        "@algolia/requester-common": "4.14.3"
+        "@algolia/requester-common": "4.16.0"
       }
     },
     "@algolia/requester-common": {
-      "version": "4.14.3",
-      "resolved": "https://registry.npmjs.org/@algolia/requester-common/-/requester-common-4.14.3.tgz",
-      "integrity": "sha512-RrRzqNyKFDP7IkTuV3XvYGF9cDPn9h6qEDl595lXva3YUk9YSS8+MGZnnkOMHvjkrSCKfoLeLbm/T4tmoIeclw=="
+      "version": "4.16.0",
+      "resolved": "https://registry.npmjs.org/@algolia/requester-common/-/requester-common-4.16.0.tgz",
+      "integrity": "sha512-3Zmcs/iMubcm4zqZ3vZG6Zum8t+hMWxGMzo0/uY2BD8o9q5vMxIYI0c4ocdgQjkXcix189WtZNkgjSOBzSbkdw=="
     },
     "@algolia/requester-node-http": {
-      "version": "4.14.3",
-      "resolved": "https://registry.npmjs.org/@algolia/requester-node-http/-/requester-node-http-4.14.3.tgz",
-      "integrity": "sha512-O5wnPxtDRPuW2U0EaOz9rMMWdlhwP0J0eSL1Z7TtXF8xnUeeUyNJrdhV5uy2CAp6RbhM1VuC3sOJcIR6Av+vbA==",
+      "version": "4.16.0",
+      "resolved": "https://registry.npmjs.org/@algolia/requester-node-http/-/requester-node-http-4.16.0.tgz",
+      "integrity": "sha512-L8JxM2VwZzh8LJ1Zb8TFS6G3icYsCKZsdWW+ahcEs1rGWmyk9SybsOe1MLnjonGBaqPWJkn9NjS7mRdjEmBtKA==",
       "requires": {
-        "@algolia/requester-common": "4.14.3"
+        "@algolia/requester-common": "4.16.0"
       }
     },
     "@algolia/transporter": {
-      "version": "4.14.3",
-      "resolved": "https://registry.npmjs.org/@algolia/transporter/-/transporter-4.14.3.tgz",
-      "integrity": "sha512-2qlKlKsnGJ008exFRb5RTeTOqhLZj0bkMCMVskxoqWejs2Q2QtWmsiH98hDfpw0fmnyhzHEt0Z7lqxBYp8bW2w==",
+      "version": "4.16.0",
+      "resolved": "https://registry.npmjs.org/@algolia/transporter/-/transporter-4.16.0.tgz",
+      "integrity": "sha512-H9BVB2EAjT65w7XGBNf5drpsW39x2aSZ942j4boSAAJPPlLmjtj5IpAP7UAtsV8g9Beslonh0bLa1XGmE/P0BA==",
       "requires": {
-        "@algolia/cache-common": "4.14.3",
-        "@algolia/logger-common": "4.14.3",
-        "@algolia/requester-common": "4.14.3"
+        "@algolia/cache-common": "4.16.0",
+        "@algolia/logger-common": "4.16.0",
+        "@algolia/requester-common": "4.16.0"
       }
     },
     "@ampproject/remapping": {
@@ -15244,11 +13934,11 @@
       }
     },
     "@babel/runtime": {
-      "version": "7.19.0",
-      "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.19.0.tgz",
-      "integrity": "sha512-eR8Lo9hnDS7tqkO7NsV+mKvCmv5boaXFSZ70DnfhcgiEne8hv9oCEd36Klw74EtizEqLsy4YnW8UWwpBVolHZA==",
+      "version": "7.21.0",
+      "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.21.0.tgz",
+      "integrity": "sha512-xwII0//EObnq89Ji5AKYQaRYiW/nZ3llSv29d49IuxPhKbtJoLP+9QUUZ4nVragQVtaVGeZrpB+ZtG/Pdy/POw==",
       "requires": {
-        "regenerator-runtime": "^0.13.4"
+        "regenerator-runtime": "^0.13.11"
       }
     },
     "@babel/runtime-corejs3": {
@@ -15304,18 +13994,18 @@
       "optional": true
     },
     "@docsearch/css": {
-      "version": "3.3.2",
-      "resolved": "https://registry.npmjs.org/@docsearch/css/-/css-3.3.2.tgz",
-      "integrity": "sha512-dctFYiwbvDZkksMlsmc7pj6W6By/EjnVXJq5TEPd05MwQe+dcdHJgaIn1c8wfsucxHpIsdrUcgSkACHCq6aIhw=="
+      "version": "3.3.3",
+      "resolved": "https://registry.npmjs.org/@docsearch/css/-/css-3.3.3.tgz",
+      "integrity": "sha512-6SCwI7P8ao+se1TUsdZ7B4XzL+gqeQZnBc+2EONZlcVa0dVrk0NjETxozFKgMv0eEGH8QzP1fkN+A1rH61l4eg=="
     },
     "@docsearch/react": {
-      "version": "3.3.2",
-      "resolved": "https://registry.npmjs.org/@docsearch/react/-/react-3.3.2.tgz",
-      "integrity": "sha512-ugILab2TYKSh6IEHf6Z9xZbOovsYbsdfo60PBj+Bw+oMJ1MHJ7pBt1TTcmPki1hSgg8mysgKy2hDiVdPm7XWSQ==",
+      "version": "3.3.3",
+      "resolved": "https://registry.npmjs.org/@docsearch/react/-/react-3.3.3.tgz",
+      "integrity": "sha512-pLa0cxnl+G0FuIDuYlW+EBK6Rw2jwLw9B1RHIeS4N4s2VhsfJ/wzeCi3CWcs5yVfxLd5ZK50t//TMA5e79YT7Q==",
       "requires": {
         "@algolia/autocomplete-core": "1.7.4",
         "@algolia/autocomplete-preset-algolia": "1.7.4",
-        "@docsearch/css": "3.3.2",
+        "@docsearch/css": "3.3.3",
         "algoliasearch": "^4.0.0"
       }
     },
@@ -15395,84 +14085,6 @@
         "webpack-dev-server": "^4.9.3",
         "webpack-merge": "^5.8.0",
         "webpackbar": "^5.0.2"
-      },
-      "dependencies": {
-        "@docusaurus/logger": {
-          "version": "2.4.0",
-          "resolved": "https://registry.npmjs.org/@docusaurus/logger/-/logger-2.4.0.tgz",
-          "integrity": "sha512-T8+qR4APN+MjcC9yL2Es+xPJ2923S9hpzDmMtdsOcUGLqpCGBbU1vp3AAqDwXtVgFkq+NsEk7sHdVsfLWR/AXw==",
-          "requires": {
-            "chalk": "^4.1.2",
-            "tslib": "^2.4.0"
-          }
-        },
-        "@docusaurus/mdx-loader": {
-          "version": "2.4.0",
-          "resolved": "https://registry.npmjs.org/@docusaurus/mdx-loader/-/mdx-loader-2.4.0.tgz",
-          "integrity": "sha512-GWoH4izZKOmFoC+gbI2/y8deH/xKLvzz/T5BsEexBye8EHQlwsA7FMrVa48N063bJBH4FUOiRRXxk5rq9cC36g==",
-          "requires": {
-            "@babel/parser": "^7.18.8",
-            "@babel/traverse": "^7.18.8",
-            "@docusaurus/logger": "2.4.0",
-            "@docusaurus/utils": "2.4.0",
-            "@mdx-js/mdx": "^1.6.22",
-            "escape-html": "^1.0.3",
-            "file-loader": "^6.2.0",
-            "fs-extra": "^10.1.0",
-            "image-size": "^1.0.1",
-            "mdast-util-to-string": "^2.0.0",
-            "remark-emoji": "^2.2.0",
-            "stringify-object": "^3.3.0",
-            "tslib": "^2.4.0",
-            "unified": "^9.2.2",
-            "unist-util-visit": "^2.0.3",
-            "url-loader": "^4.1.1",
-            "webpack": "^5.73.0"
-          }
-        },
-        "@docusaurus/utils": {
-          "version": "2.4.0",
-          "resolved": "https://registry.npmjs.org/@docusaurus/utils/-/utils-2.4.0.tgz",
-          "integrity": "sha512-89hLYkvtRX92j+C+ERYTuSUK6nF9bGM32QThcHPg2EDDHVw6FzYQXmX6/p+pU5SDyyx5nBlE4qXR92RxCAOqfg==",
-          "requires": {
-            "@docusaurus/logger": "2.4.0",
-            "@svgr/webpack": "^6.2.1",
-            "escape-string-regexp": "^4.0.0",
-            "file-loader": "^6.2.0",
-            "fs-extra": "^10.1.0",
-            "github-slugger": "^1.4.0",
-            "globby": "^11.1.0",
-            "gray-matter": "^4.0.3",
-            "js-yaml": "^4.1.0",
-            "lodash": "^4.17.21",
-            "micromatch": "^4.0.5",
-            "resolve-pathname": "^3.0.0",
-            "shelljs": "^0.8.5",
-            "tslib": "^2.4.0",
-            "url-loader": "^4.1.1",
-            "webpack": "^5.73.0"
-          }
-        },
-        "@docusaurus/utils-common": {
-          "version": "2.4.0",
-          "resolved": "https://registry.npmjs.org/@docusaurus/utils-common/-/utils-common-2.4.0.tgz",
-          "integrity": "sha512-zIMf10xuKxddYfLg5cS19x44zud/E9I7lj3+0bv8UIs0aahpErfNrGhijEfJpAfikhQ8tL3m35nH3hJ3sOG82A==",
-          "requires": {
-            "tslib": "^2.4.0"
-          }
-        },
-        "@docusaurus/utils-validation": {
-          "version": "2.4.0",
-          "resolved": "https://registry.npmjs.org/@docusaurus/utils-validation/-/utils-validation-2.4.0.tgz",
-          "integrity": "sha512-IrBsBbbAp6y7mZdJx4S4pIA7dUyWSA0GNosPk6ZJ0fX3uYIEQgcQSGIgTeSC+8xPEx3c16o03en1jSDpgQgz/w==",
-          "requires": {
-            "@docusaurus/logger": "2.4.0",
-            "@docusaurus/utils": "2.4.0",
-            "joi": "^17.6.0",
-            "js-yaml": "^4.1.0",
-            "tslib": "^2.4.0"
-          }
-        }
       }
     },
     "@docusaurus/cssnano-preset": {
@@ -15487,23 +14099,23 @@
       }
     },
     "@docusaurus/logger": {
-      "version": "2.3.1",
-      "resolved": "https://registry.npmjs.org/@docusaurus/logger/-/logger-2.3.1.tgz",
-      "integrity": "sha512-2lAV/olKKVr9qJhfHFCaqBIl8FgYjbUFwgUnX76+cULwQYss+42ZQ3grHGFvI0ocN2X55WcYe64ellQXz7suqg==",
+      "version": "2.4.0",
+      "resolved": "https://registry.npmjs.org/@docusaurus/logger/-/logger-2.4.0.tgz",
+      "integrity": "sha512-T8+qR4APN+MjcC9yL2Es+xPJ2923S9hpzDmMtdsOcUGLqpCGBbU1vp3AAqDwXtVgFkq+NsEk7sHdVsfLWR/AXw==",
       "requires": {
         "chalk": "^4.1.2",
         "tslib": "^2.4.0"
       }
     },
     "@docusaurus/mdx-loader": {
-      "version": "2.3.1",
-      "resolved": "https://registry.npmjs.org/@docusaurus/mdx-loader/-/mdx-loader-2.3.1.tgz",
-      "integrity": "sha512-Gzga7OsxQRpt3392K9lv/bW4jGppdLFJh3luKRknCKSAaZrmVkOQv2gvCn8LAOSZ3uRg5No7AgYs/vpL8K94lA==",
+      "version": "2.4.0",
+      "resolved": "https://registry.npmjs.org/@docusaurus/mdx-loader/-/mdx-loader-2.4.0.tgz",
+      "integrity": "sha512-GWoH4izZKOmFoC+gbI2/y8deH/xKLvzz/T5BsEexBye8EHQlwsA7FMrVa48N063bJBH4FUOiRRXxk5rq9cC36g==",
       "requires": {
         "@babel/parser": "^7.18.8",
         "@babel/traverse": "^7.18.8",
-        "@docusaurus/logger": "2.3.1",
-        "@docusaurus/utils": "2.3.1",
+        "@docusaurus/logger": "2.4.0",
+        "@docusaurus/utils": "2.4.0",
         "@mdx-js/mdx": "^1.6.22",
         "escape-html": "^1.0.3",
         "file-loader": "^6.2.0",
@@ -15523,7 +14135,6 @@
       "version": "2.4.0",
       "resolved": "https://registry.npmjs.org/@docusaurus/module-type-aliases/-/module-type-aliases-2.4.0.tgz",
       "integrity": "sha512-YEQO2D3UXs72qCn8Cr+RlycSQXVGN9iEUyuHwTuK4/uL/HFomB2FHSU0vSDM23oLd+X/KibQ3Ez6nGjQLqXcHg==",
-      "dev": true,
       "requires": {
         "@docusaurus/react-loadable": "5.5.2",
         "@docusaurus/types": "2.4.0",
@@ -15533,38 +14144,20 @@
         "@types/react-router-dom": "*",
         "react-helmet-async": "*",
         "react-loadable": "npm:@docusaurus/react-loadable@5.5.2"
-      },
-      "dependencies": {
-        "@docusaurus/types": {
-          "version": "2.4.0",
-          "resolved": "https://registry.npmjs.org/@docusaurus/types/-/types-2.4.0.tgz",
-          "integrity": "sha512-xaBXr+KIPDkIaef06c+i2HeTqVNixB7yFut5fBXPGI2f1rrmEV2vLMznNGsFwvZ5XmA3Quuefd4OGRkdo97Dhw==",
-          "dev": true,
-          "requires": {
-            "@types/history": "^4.7.11",
-            "@types/react": "*",
-            "commander": "^5.1.0",
-            "joi": "^17.6.0",
-            "react-helmet-async": "^1.3.0",
-            "utility-types": "^3.10.0",
-            "webpack": "^5.73.0",
-            "webpack-merge": "^5.8.0"
-          }
-        }
       }
     },
     "@docusaurus/plugin-content-blog": {
-      "version": "2.3.1",
-      "resolved": "https://registry.npmjs.org/@docusaurus/plugin-content-blog/-/plugin-content-blog-2.3.1.tgz",
-      "integrity": "sha512-f5LjqX+9WkiLyGiQ41x/KGSJ/9bOjSD8lsVhPvYeUYHCtYpuiDKfhZE07O4EqpHkBx4NQdtQDbp+aptgHSTuiw==",
+      "version": "2.4.0",
+      "resolved": "https://registry.npmjs.org/@docusaurus/plugin-content-blog/-/plugin-content-blog-2.4.0.tgz",
+      "integrity": "sha512-YwkAkVUxtxoBAIj/MCb4ohN0SCtHBs4AS75jMhPpf67qf3j+U/4n33cELq7567hwyZ6fMz2GPJcVmctzlGGThQ==",
       "requires": {
-        "@docusaurus/core": "2.3.1",
-        "@docusaurus/logger": "2.3.1",
-        "@docusaurus/mdx-loader": "2.3.1",
-        "@docusaurus/types": "2.3.1",
-        "@docusaurus/utils": "2.3.1",
-        "@docusaurus/utils-common": "2.3.1",
-        "@docusaurus/utils-validation": "2.3.1",
+        "@docusaurus/core": "2.4.0",
+        "@docusaurus/logger": "2.4.0",
+        "@docusaurus/mdx-loader": "2.4.0",
+        "@docusaurus/types": "2.4.0",
+        "@docusaurus/utils": "2.4.0",
+        "@docusaurus/utils-common": "2.4.0",
+        "@docusaurus/utils-validation": "2.4.0",
         "cheerio": "^1.0.0-rc.12",
         "feed": "^4.2.2",
         "fs-extra": "^10.1.0",
@@ -15574,111 +14167,20 @@
         "unist-util-visit": "^2.0.3",
         "utility-types": "^3.10.0",
         "webpack": "^5.73.0"
-      },
-      "dependencies": {
-        "@docusaurus/core": {
-          "version": "2.3.1",
-          "resolved": "https://registry.npmjs.org/@docusaurus/core/-/core-2.3.1.tgz",
-          "integrity": "sha512-0Jd4jtizqnRAr7svWaBbbrCCN8mzBNd2xFLoT/IM7bGfFie5y58oz97KzXliwiLY3zWjqMXjQcuP1a5VgCv2JA==",
-          "requires": {
-            "@babel/core": "^7.18.6",
-            "@babel/generator": "^7.18.7",
-            "@babel/plugin-syntax-dynamic-import": "^7.8.3",
-            "@babel/plugin-transform-runtime": "^7.18.6",
-            "@babel/preset-env": "^7.18.6",
-            "@babel/preset-react": "^7.18.6",
-            "@babel/preset-typescript": "^7.18.6",
-            "@babel/runtime": "^7.18.6",
-            "@babel/runtime-corejs3": "^7.18.6",
-            "@babel/traverse": "^7.18.8",
-            "@docusaurus/cssnano-preset": "2.3.1",
-            "@docusaurus/logger": "2.3.1",
-            "@docusaurus/mdx-loader": "2.3.1",
-            "@docusaurus/react-loadable": "5.5.2",
-            "@docusaurus/utils": "2.3.1",
-            "@docusaurus/utils-common": "2.3.1",
-            "@docusaurus/utils-validation": "2.3.1",
-            "@slorber/static-site-generator-webpack-plugin": "^4.0.7",
-            "@svgr/webpack": "^6.2.1",
-            "autoprefixer": "^10.4.7",
-            "babel-loader": "^8.2.5",
-            "babel-plugin-dynamic-import-node": "^2.3.3",
-            "boxen": "^6.2.1",
-            "chalk": "^4.1.2",
-            "chokidar": "^3.5.3",
-            "clean-css": "^5.3.0",
-            "cli-table3": "^0.6.2",
-            "combine-promises": "^1.1.0",
-            "commander": "^5.1.0",
-            "copy-webpack-plugin": "^11.0.0",
-            "core-js": "^3.23.3",
-            "css-loader": "^6.7.1",
-            "css-minimizer-webpack-plugin": "^4.0.0",
-            "cssnano": "^5.1.12",
-            "del": "^6.1.1",
-            "detect-port": "^1.3.0",
-            "escape-html": "^1.0.3",
-            "eta": "^2.0.0",
-            "file-loader": "^6.2.0",
-            "fs-extra": "^10.1.0",
-            "html-minifier-terser": "^6.1.0",
-            "html-tags": "^3.2.0",
-            "html-webpack-plugin": "^5.5.0",
-            "import-fresh": "^3.3.0",
-            "leven": "^3.1.0",
-            "lodash": "^4.17.21",
-            "mini-css-extract-plugin": "^2.6.1",
-            "postcss": "^8.4.14",
-            "postcss-loader": "^7.0.0",
-            "prompts": "^2.4.2",
-            "react-dev-utils": "^12.0.1",
-            "react-helmet-async": "^1.3.0",
-            "react-loadable": "npm:@docusaurus/react-loadable@5.5.2",
-            "react-loadable-ssr-addon-v5-slorber": "^1.0.1",
-            "react-router": "^5.3.3",
-            "react-router-config": "^5.1.1",
-            "react-router-dom": "^5.3.3",
-            "rtl-detect": "^1.0.4",
-            "semver": "^7.3.7",
-            "serve-handler": "^6.1.3",
-            "shelljs": "^0.8.5",
-            "terser-webpack-plugin": "^5.3.3",
-            "tslib": "^2.4.0",
-            "update-notifier": "^5.1.0",
-            "url-loader": "^4.1.1",
-            "wait-on": "^6.0.1",
-            "webpack": "^5.73.0",
-            "webpack-bundle-analyzer": "^4.5.0",
-            "webpack-dev-server": "^4.9.3",
-            "webpack-merge": "^5.8.0",
-            "webpackbar": "^5.0.2"
-          }
-        },
-        "@docusaurus/cssnano-preset": {
-          "version": "2.3.1",
-          "resolved": "https://registry.npmjs.org/@docusaurus/cssnano-preset/-/cssnano-preset-2.3.1.tgz",
-          "integrity": "sha512-7mIhAROES6CY1GmCjR4CZkUfjTL6B3u6rKHK0ChQl2d1IevYXq/k/vFgvOrJfcKxiObpMnE9+X6R2Wt1KqxC6w==",
-          "requires": {
-            "cssnano-preset-advanced": "^5.3.8",
-            "postcss": "^8.4.14",
-            "postcss-sort-media-queries": "^4.2.1",
-            "tslib": "^2.4.0"
-          }
-        }
       }
     },
     "@docusaurus/plugin-content-docs": {
-      "version": "2.3.1",
-      "resolved": "https://registry.npmjs.org/@docusaurus/plugin-content-docs/-/plugin-content-docs-2.3.1.tgz",
-      "integrity": "sha512-DxztTOBEruv7qFxqUtbsqXeNcHqcVEIEe+NQoI1oi2DBmKBhW/o0MIal8lt+9gvmpx3oYtlwmLOOGepxZgJGkw==",
+      "version": "2.4.0",
+      "resolved": "https://registry.npmjs.org/@docusaurus/plugin-content-docs/-/plugin-content-docs-2.4.0.tgz",
+      "integrity": "sha512-ic/Z/ZN5Rk/RQo+Io6rUGpToOtNbtPloMR2JcGwC1xT2riMu6zzfSwmBi9tHJgdXH6CB5jG+0dOZZO8QS5tmDg==",
       "requires": {
-        "@docusaurus/core": "2.3.1",
-        "@docusaurus/logger": "2.3.1",
-        "@docusaurus/mdx-loader": "2.3.1",
-        "@docusaurus/module-type-aliases": "2.3.1",
-        "@docusaurus/types": "2.3.1",
-        "@docusaurus/utils": "2.3.1",
-        "@docusaurus/utils-validation": "2.3.1",
+        "@docusaurus/core": "2.4.0",
+        "@docusaurus/logger": "2.4.0",
+        "@docusaurus/mdx-loader": "2.4.0",
+        "@docusaurus/module-type-aliases": "2.4.0",
+        "@docusaurus/types": "2.4.0",
+        "@docusaurus/utils": "2.4.0",
+        "@docusaurus/utils-validation": "2.4.0",
         "@types/react-router-config": "^5.0.6",
         "combine-promises": "^1.1.0",
         "fs-extra": "^10.1.0",
@@ -15688,846 +14190,103 @@
         "tslib": "^2.4.0",
         "utility-types": "^3.10.0",
         "webpack": "^5.73.0"
-      },
-      "dependencies": {
-        "@docusaurus/core": {
-          "version": "2.3.1",
-          "resolved": "https://registry.npmjs.org/@docusaurus/core/-/core-2.3.1.tgz",
-          "integrity": "sha512-0Jd4jtizqnRAr7svWaBbbrCCN8mzBNd2xFLoT/IM7bGfFie5y58oz97KzXliwiLY3zWjqMXjQcuP1a5VgCv2JA==",
-          "requires": {
-            "@babel/core": "^7.18.6",
-            "@babel/generator": "^7.18.7",
-            "@babel/plugin-syntax-dynamic-import": "^7.8.3",
-            "@babel/plugin-transform-runtime": "^7.18.6",
-            "@babel/preset-env": "^7.18.6",
-            "@babel/preset-react": "^7.18.6",
-            "@babel/preset-typescript": "^7.18.6",
-            "@babel/runtime": "^7.18.6",
-            "@babel/runtime-corejs3": "^7.18.6",
-            "@babel/traverse": "^7.18.8",
-            "@docusaurus/cssnano-preset": "2.3.1",
-            "@docusaurus/logger": "2.3.1",
-            "@docusaurus/mdx-loader": "2.3.1",
-            "@docusaurus/react-loadable": "5.5.2",
-            "@docusaurus/utils": "2.3.1",
-            "@docusaurus/utils-common": "2.3.1",
-            "@docusaurus/utils-validation": "2.3.1",
-            "@slorber/static-site-generator-webpack-plugin": "^4.0.7",
-            "@svgr/webpack": "^6.2.1",
-            "autoprefixer": "^10.4.7",
-            "babel-loader": "^8.2.5",
-            "babel-plugin-dynamic-import-node": "^2.3.3",
-            "boxen": "^6.2.1",
-            "chalk": "^4.1.2",
-            "chokidar": "^3.5.3",
-            "clean-css": "^5.3.0",
-            "cli-table3": "^0.6.2",
-            "combine-promises": "^1.1.0",
-            "commander": "^5.1.0",
-            "copy-webpack-plugin": "^11.0.0",
-            "core-js": "^3.23.3",
-            "css-loader": "^6.7.1",
-            "css-minimizer-webpack-plugin": "^4.0.0",
-            "cssnano": "^5.1.12",
-            "del": "^6.1.1",
-            "detect-port": "^1.3.0",
-            "escape-html": "^1.0.3",
-            "eta": "^2.0.0",
-            "file-loader": "^6.2.0",
-            "fs-extra": "^10.1.0",
-            "html-minifier-terser": "^6.1.0",
-            "html-tags": "^3.2.0",
-            "html-webpack-plugin": "^5.5.0",
-            "import-fresh": "^3.3.0",
-            "leven": "^3.1.0",
-            "lodash": "^4.17.21",
-            "mini-css-extract-plugin": "^2.6.1",
-            "postcss": "^8.4.14",
-            "postcss-loader": "^7.0.0",
-            "prompts": "^2.4.2",
-            "react-dev-utils": "^12.0.1",
-            "react-helmet-async": "^1.3.0",
-            "react-loadable": "npm:@docusaurus/react-loadable@5.5.2",
-            "react-loadable-ssr-addon-v5-slorber": "^1.0.1",
-            "react-router": "^5.3.3",
-            "react-router-config": "^5.1.1",
-            "react-router-dom": "^5.3.3",
-            "rtl-detect": "^1.0.4",
-            "semver": "^7.3.7",
-            "serve-handler": "^6.1.3",
-            "shelljs": "^0.8.5",
-            "terser-webpack-plugin": "^5.3.3",
-            "tslib": "^2.4.0",
-            "update-notifier": "^5.1.0",
-            "url-loader": "^4.1.1",
-            "wait-on": "^6.0.1",
-            "webpack": "^5.73.0",
-            "webpack-bundle-analyzer": "^4.5.0",
-            "webpack-dev-server": "^4.9.3",
-            "webpack-merge": "^5.8.0",
-            "webpackbar": "^5.0.2"
-          }
-        },
-        "@docusaurus/cssnano-preset": {
-          "version": "2.3.1",
-          "resolved": "https://registry.npmjs.org/@docusaurus/cssnano-preset/-/cssnano-preset-2.3.1.tgz",
-          "integrity": "sha512-7mIhAROES6CY1GmCjR4CZkUfjTL6B3u6rKHK0ChQl2d1IevYXq/k/vFgvOrJfcKxiObpMnE9+X6R2Wt1KqxC6w==",
-          "requires": {
-            "cssnano-preset-advanced": "^5.3.8",
-            "postcss": "^8.4.14",
-            "postcss-sort-media-queries": "^4.2.1",
-            "tslib": "^2.4.0"
-          }
-        },
-        "@docusaurus/module-type-aliases": {
-          "version": "2.3.1",
-          "resolved": "https://registry.npmjs.org/@docusaurus/module-type-aliases/-/module-type-aliases-2.3.1.tgz",
-          "integrity": "sha512-6KkxfAVOJqIUynTRb/tphYCl+co3cP0PlHiMDbi+SzmYxMdgIrwYqH9yAnGSDoN6Jk2ZE/JY/Azs/8LPgKP48A==",
-          "requires": {
-            "@docusaurus/react-loadable": "5.5.2",
-            "@docusaurus/types": "2.3.1",
-            "@types/history": "^4.7.11",
-            "@types/react": "*",
-            "@types/react-router-config": "*",
-            "@types/react-router-dom": "*",
-            "react-helmet-async": "*",
-            "react-loadable": "npm:@docusaurus/react-loadable@5.5.2"
-          }
-        }
       }
     },
     "@docusaurus/plugin-content-pages": {
-      "version": "2.3.1",
-      "resolved": "https://registry.npmjs.org/@docusaurus/plugin-content-pages/-/plugin-content-pages-2.3.1.tgz",
-      "integrity": "sha512-E80UL6hvKm5VVw8Ka8YaVDtO6kWWDVUK4fffGvkpQ/AJQDOg99LwOXKujPoICC22nUFTsZ2Hp70XvpezCsFQaA==",
+      "version": "2.4.0",
+      "resolved": "https://registry.npmjs.org/@docusaurus/plugin-content-pages/-/plugin-content-pages-2.4.0.tgz",
+      "integrity": "sha512-Pk2pOeOxk8MeU3mrTU0XLIgP9NZixbdcJmJ7RUFrZp1Aj42nd0RhIT14BGvXXyqb8yTQlk4DmYGAzqOfBsFyGw==",
       "requires": {
-        "@docusaurus/core": "2.3.1",
-        "@docusaurus/mdx-loader": "2.3.1",
-        "@docusaurus/types": "2.3.1",
-        "@docusaurus/utils": "2.3.1",
-        "@docusaurus/utils-validation": "2.3.1",
+        "@docusaurus/core": "2.4.0",
+        "@docusaurus/mdx-loader": "2.4.0",
+        "@docusaurus/types": "2.4.0",
+        "@docusaurus/utils": "2.4.0",
+        "@docusaurus/utils-validation": "2.4.0",
         "fs-extra": "^10.1.0",
         "tslib": "^2.4.0",
         "webpack": "^5.73.0"
-      },
-      "dependencies": {
-        "@docusaurus/core": {
-          "version": "2.3.1",
-          "resolved": "https://registry.npmjs.org/@docusaurus/core/-/core-2.3.1.tgz",
-          "integrity": "sha512-0Jd4jtizqnRAr7svWaBbbrCCN8mzBNd2xFLoT/IM7bGfFie5y58oz97KzXliwiLY3zWjqMXjQcuP1a5VgCv2JA==",
-          "requires": {
-            "@babel/core": "^7.18.6",
-            "@babel/generator": "^7.18.7",
-            "@babel/plugin-syntax-dynamic-import": "^7.8.3",
-            "@babel/plugin-transform-runtime": "^7.18.6",
-            "@babel/preset-env": "^7.18.6",
-            "@babel/preset-react": "^7.18.6",
-            "@babel/preset-typescript": "^7.18.6",
-            "@babel/runtime": "^7.18.6",
-            "@babel/runtime-corejs3": "^7.18.6",
-            "@babel/traverse": "^7.18.8",
-            "@docusaurus/cssnano-preset": "2.3.1",
-            "@docusaurus/logger": "2.3.1",
-            "@docusaurus/mdx-loader": "2.3.1",
-            "@docusaurus/react-loadable": "5.5.2",
-            "@docusaurus/utils": "2.3.1",
-            "@docusaurus/utils-common": "2.3.1",
-            "@docusaurus/utils-validation": "2.3.1",
-            "@slorber/static-site-generator-webpack-plugin": "^4.0.7",
-            "@svgr/webpack": "^6.2.1",
-            "autoprefixer": "^10.4.7",
-            "babel-loader": "^8.2.5",
-            "babel-plugin-dynamic-import-node": "^2.3.3",
-            "boxen": "^6.2.1",
-            "chalk": "^4.1.2",
-            "chokidar": "^3.5.3",
-            "clean-css": "^5.3.0",
-            "cli-table3": "^0.6.2",
-            "combine-promises": "^1.1.0",
-            "commander": "^5.1.0",
-            "copy-webpack-plugin": "^11.0.0",
-            "core-js": "^3.23.3",
-            "css-loader": "^6.7.1",
-            "css-minimizer-webpack-plugin": "^4.0.0",
-            "cssnano": "^5.1.12",
-            "del": "^6.1.1",
-            "detect-port": "^1.3.0",
-            "escape-html": "^1.0.3",
-            "eta": "^2.0.0",
-            "file-loader": "^6.2.0",
-            "fs-extra": "^10.1.0",
-            "html-minifier-terser": "^6.1.0",
-            "html-tags": "^3.2.0",
-            "html-webpack-plugin": "^5.5.0",
-            "import-fresh": "^3.3.0",
-            "leven": "^3.1.0",
-            "lodash": "^4.17.21",
-            "mini-css-extract-plugin": "^2.6.1",
-            "postcss": "^8.4.14",
-            "postcss-loader": "^7.0.0",
-            "prompts": "^2.4.2",
-            "react-dev-utils": "^12.0.1",
-            "react-helmet-async": "^1.3.0",
-            "react-loadable": "npm:@docusaurus/react-loadable@5.5.2",
-            "react-loadable-ssr-addon-v5-slorber": "^1.0.1",
-            "react-router": "^5.3.3",
-            "react-router-config": "^5.1.1",
-            "react-router-dom": "^5.3.3",
-            "rtl-detect": "^1.0.4",
-            "semver": "^7.3.7",
-            "serve-handler": "^6.1.3",
-            "shelljs": "^0.8.5",
-            "terser-webpack-plugin": "^5.3.3",
-            "tslib": "^2.4.0",
-            "update-notifier": "^5.1.0",
-            "url-loader": "^4.1.1",
-            "wait-on": "^6.0.1",
-            "webpack": "^5.73.0",
-            "webpack-bundle-analyzer": "^4.5.0",
-            "webpack-dev-server": "^4.9.3",
-            "webpack-merge": "^5.8.0",
-            "webpackbar": "^5.0.2"
-          }
-        },
-        "@docusaurus/cssnano-preset": {
-          "version": "2.3.1",
-          "resolved": "https://registry.npmjs.org/@docusaurus/cssnano-preset/-/cssnano-preset-2.3.1.tgz",
-          "integrity": "sha512-7mIhAROES6CY1GmCjR4CZkUfjTL6B3u6rKHK0ChQl2d1IevYXq/k/vFgvOrJfcKxiObpMnE9+X6R2Wt1KqxC6w==",
-          "requires": {
-            "cssnano-preset-advanced": "^5.3.8",
-            "postcss": "^8.4.14",
-            "postcss-sort-media-queries": "^4.2.1",
-            "tslib": "^2.4.0"
-          }
-        }
       }
     },
     "@docusaurus/plugin-debug": {
-      "version": "2.3.1",
-      "resolved": "https://registry.npmjs.org/@docusaurus/plugin-debug/-/plugin-debug-2.3.1.tgz",
-      "integrity": "sha512-Ujpml1Ppg4geB/2hyu2diWnO49az9U2bxM9Shen7b6qVcyFisNJTkVG2ocvLC7wM1efTJcUhBO6zAku2vKJGMw==",
+      "version": "2.4.0",
+      "resolved": "https://registry.npmjs.org/@docusaurus/plugin-debug/-/plugin-debug-2.4.0.tgz",
+      "integrity": "sha512-KC56DdYjYT7Txyux71vXHXGYZuP6yYtqwClvYpjKreWIHWus5Zt6VNi23rMZv3/QKhOCrN64zplUbdfQMvddBQ==",
       "requires": {
-        "@docusaurus/core": "2.3.1",
-        "@docusaurus/types": "2.3.1",
-        "@docusaurus/utils": "2.3.1",
+        "@docusaurus/core": "2.4.0",
+        "@docusaurus/types": "2.4.0",
+        "@docusaurus/utils": "2.4.0",
         "fs-extra": "^10.1.0",
         "react-json-view": "^1.21.3",
         "tslib": "^2.4.0"
-      },
-      "dependencies": {
-        "@docusaurus/core": {
-          "version": "2.3.1",
-          "resolved": "https://registry.npmjs.org/@docusaurus/core/-/core-2.3.1.tgz",
-          "integrity": "sha512-0Jd4jtizqnRAr7svWaBbbrCCN8mzBNd2xFLoT/IM7bGfFie5y58oz97KzXliwiLY3zWjqMXjQcuP1a5VgCv2JA==",
-          "requires": {
-            "@babel/core": "^7.18.6",
-            "@babel/generator": "^7.18.7",
-            "@babel/plugin-syntax-dynamic-import": "^7.8.3",
-            "@babel/plugin-transform-runtime": "^7.18.6",
-            "@babel/preset-env": "^7.18.6",
-            "@babel/preset-react": "^7.18.6",
-            "@babel/preset-typescript": "^7.18.6",
-            "@babel/runtime": "^7.18.6",
-            "@babel/runtime-corejs3": "^7.18.6",
-            "@babel/traverse": "^7.18.8",
-            "@docusaurus/cssnano-preset": "2.3.1",
-            "@docusaurus/logger": "2.3.1",
-            "@docusaurus/mdx-loader": "2.3.1",
-            "@docusaurus/react-loadable": "5.5.2",
-            "@docusaurus/utils": "2.3.1",
-            "@docusaurus/utils-common": "2.3.1",
-            "@docusaurus/utils-validation": "2.3.1",
-            "@slorber/static-site-generator-webpack-plugin": "^4.0.7",
-            "@svgr/webpack": "^6.2.1",
-            "autoprefixer": "^10.4.7",
-            "babel-loader": "^8.2.5",
-            "babel-plugin-dynamic-import-node": "^2.3.3",
-            "boxen": "^6.2.1",
-            "chalk": "^4.1.2",
-            "chokidar": "^3.5.3",
-            "clean-css": "^5.3.0",
-            "cli-table3": "^0.6.2",
-            "combine-promises": "^1.1.0",
-            "commander": "^5.1.0",
-            "copy-webpack-plugin": "^11.0.0",
-            "core-js": "^3.23.3",
-            "css-loader": "^6.7.1",
-            "css-minimizer-webpack-plugin": "^4.0.0",
-            "cssnano": "^5.1.12",
-            "del": "^6.1.1",
-            "detect-port": "^1.3.0",
-            "escape-html": "^1.0.3",
-            "eta": "^2.0.0",
-            "file-loader": "^6.2.0",
-            "fs-extra": "^10.1.0",
-            "html-minifier-terser": "^6.1.0",
-            "html-tags": "^3.2.0",
-            "html-webpack-plugin": "^5.5.0",
-            "import-fresh": "^3.3.0",
-            "leven": "^3.1.0",
-            "lodash": "^4.17.21",
-            "mini-css-extract-plugin": "^2.6.1",
-            "postcss": "^8.4.14",
-            "postcss-loader": "^7.0.0",
-            "prompts": "^2.4.2",
-            "react-dev-utils": "^12.0.1",
-            "react-helmet-async": "^1.3.0",
-            "react-loadable": "npm:@docusaurus/react-loadable@5.5.2",
-            "react-loadable-ssr-addon-v5-slorber": "^1.0.1",
-            "react-router": "^5.3.3",
-            "react-router-config": "^5.1.1",
-            "react-router-dom": "^5.3.3",
-            "rtl-detect": "^1.0.4",
-            "semver": "^7.3.7",
-            "serve-handler": "^6.1.3",
-            "shelljs": "^0.8.5",
-            "terser-webpack-plugin": "^5.3.3",
-            "tslib": "^2.4.0",
-            "update-notifier": "^5.1.0",
-            "url-loader": "^4.1.1",
-            "wait-on": "^6.0.1",
-            "webpack": "^5.73.0",
-            "webpack-bundle-analyzer": "^4.5.0",
-            "webpack-dev-server": "^4.9.3",
-            "webpack-merge": "^5.8.0",
-            "webpackbar": "^5.0.2"
-          }
-        },
-        "@docusaurus/cssnano-preset": {
-          "version": "2.3.1",
-          "resolved": "https://registry.npmjs.org/@docusaurus/cssnano-preset/-/cssnano-preset-2.3.1.tgz",
-          "integrity": "sha512-7mIhAROES6CY1GmCjR4CZkUfjTL6B3u6rKHK0ChQl2d1IevYXq/k/vFgvOrJfcKxiObpMnE9+X6R2Wt1KqxC6w==",
-          "requires": {
-            "cssnano-preset-advanced": "^5.3.8",
-            "postcss": "^8.4.14",
-            "postcss-sort-media-queries": "^4.2.1",
-            "tslib": "^2.4.0"
-          }
-        }
       }
     },
     "@docusaurus/plugin-google-analytics": {
-      "version": "2.3.1",
-      "resolved": "https://registry.npmjs.org/@docusaurus/plugin-google-analytics/-/plugin-google-analytics-2.3.1.tgz",
-      "integrity": "sha512-OHip0GQxKOFU8n7gkt3TM4HOYTXPCFDjqKbMClDD3KaDnyTuMp/Zvd9HSr770lLEscgPWIvzhJByRAClqsUWiQ==",
+      "version": "2.4.0",
+      "resolved": "https://registry.npmjs.org/@docusaurus/plugin-google-analytics/-/plugin-google-analytics-2.4.0.tgz",
+      "integrity": "sha512-uGUzX67DOAIglygdNrmMOvEp8qG03X20jMWadeqVQktS6nADvozpSLGx4J0xbkblhJkUzN21WiilsP9iVP+zkw==",
       "requires": {
-        "@docusaurus/core": "2.3.1",
-        "@docusaurus/types": "2.3.1",
-        "@docusaurus/utils-validation": "2.3.1",
+        "@docusaurus/core": "2.4.0",
+        "@docusaurus/types": "2.4.0",
+        "@docusaurus/utils-validation": "2.4.0",
         "tslib": "^2.4.0"
-      },
-      "dependencies": {
-        "@docusaurus/core": {
-          "version": "2.3.1",
-          "resolved": "https://registry.npmjs.org/@docusaurus/core/-/core-2.3.1.tgz",
-          "integrity": "sha512-0Jd4jtizqnRAr7svWaBbbrCCN8mzBNd2xFLoT/IM7bGfFie5y58oz97KzXliwiLY3zWjqMXjQcuP1a5VgCv2JA==",
-          "requires": {
-            "@babel/core": "^7.18.6",
-            "@babel/generator": "^7.18.7",
-            "@babel/plugin-syntax-dynamic-import": "^7.8.3",
-            "@babel/plugin-transform-runtime": "^7.18.6",
-            "@babel/preset-env": "^7.18.6",
-            "@babel/preset-react": "^7.18.6",
-            "@babel/preset-typescript": "^7.18.6",
-            "@babel/runtime": "^7.18.6",
-            "@babel/runtime-corejs3": "^7.18.6",
-            "@babel/traverse": "^7.18.8",
-            "@docusaurus/cssnano-preset": "2.3.1",
-            "@docusaurus/logger": "2.3.1",
-            "@docusaurus/mdx-loader": "2.3.1",
-            "@docusaurus/react-loadable": "5.5.2",
-            "@docusaurus/utils": "2.3.1",
-            "@docusaurus/utils-common": "2.3.1",
-            "@docusaurus/utils-validation": "2.3.1",
-            "@slorber/static-site-generator-webpack-plugin": "^4.0.7",
-            "@svgr/webpack": "^6.2.1",
-            "autoprefixer": "^10.4.7",
-            "babel-loader": "^8.2.5",
-            "babel-plugin-dynamic-import-node": "^2.3.3",
-            "boxen": "^6.2.1",
-            "chalk": "^4.1.2",
-            "chokidar": "^3.5.3",
-            "clean-css": "^5.3.0",
-            "cli-table3": "^0.6.2",
-            "combine-promises": "^1.1.0",
-            "commander": "^5.1.0",
-            "copy-webpack-plugin": "^11.0.0",
-            "core-js": "^3.23.3",
-            "css-loader": "^6.7.1",
-            "css-minimizer-webpack-plugin": "^4.0.0",
-            "cssnano": "^5.1.12",
-            "del": "^6.1.1",
-            "detect-port": "^1.3.0",
-            "escape-html": "^1.0.3",
-            "eta": "^2.0.0",
-            "file-loader": "^6.2.0",
-            "fs-extra": "^10.1.0",
-            "html-minifier-terser": "^6.1.0",
-            "html-tags": "^3.2.0",
-            "html-webpack-plugin": "^5.5.0",
-            "import-fresh": "^3.3.0",
-            "leven": "^3.1.0",
-            "lodash": "^4.17.21",
-            "mini-css-extract-plugin": "^2.6.1",
-            "postcss": "^8.4.14",
-            "postcss-loader": "^7.0.0",
-            "prompts": "^2.4.2",
-            "react-dev-utils": "^12.0.1",
-            "react-helmet-async": "^1.3.0",
-            "react-loadable": "npm:@docusaurus/react-loadable@5.5.2",
-            "react-loadable-ssr-addon-v5-slorber": "^1.0.1",
-            "react-router": "^5.3.3",
-            "react-router-config": "^5.1.1",
-            "react-router-dom": "^5.3.3",
-            "rtl-detect": "^1.0.4",
-            "semver": "^7.3.7",
-            "serve-handler": "^6.1.3",
-            "shelljs": "^0.8.5",
-            "terser-webpack-plugin": "^5.3.3",
-            "tslib": "^2.4.0",
-            "update-notifier": "^5.1.0",
-            "url-loader": "^4.1.1",
-            "wait-on": "^6.0.1",
-            "webpack": "^5.73.0",
-            "webpack-bundle-analyzer": "^4.5.0",
-            "webpack-dev-server": "^4.9.3",
-            "webpack-merge": "^5.8.0",
-            "webpackbar": "^5.0.2"
-          }
-        },
-        "@docusaurus/cssnano-preset": {
-          "version": "2.3.1",
-          "resolved": "https://registry.npmjs.org/@docusaurus/cssnano-preset/-/cssnano-preset-2.3.1.tgz",
-          "integrity": "sha512-7mIhAROES6CY1GmCjR4CZkUfjTL6B3u6rKHK0ChQl2d1IevYXq/k/vFgvOrJfcKxiObpMnE9+X6R2Wt1KqxC6w==",
-          "requires": {
-            "cssnano-preset-advanced": "^5.3.8",
-            "postcss": "^8.4.14",
-            "postcss-sort-media-queries": "^4.2.1",
-            "tslib": "^2.4.0"
-          }
-        }
       }
     },
     "@docusaurus/plugin-google-gtag": {
-      "version": "2.3.1",
-      "resolved": "https://registry.npmjs.org/@docusaurus/plugin-google-gtag/-/plugin-google-gtag-2.3.1.tgz",
-      "integrity": "sha512-uXtDhfu4+Hm+oqWUySr3DNI5cWC/rmP6XJyAk83Heor3dFjZqDwCbkX8yWPywkRiWev3Dk/rVF8lEn0vIGVocA==",
+      "version": "2.4.0",
+      "resolved": "https://registry.npmjs.org/@docusaurus/plugin-google-gtag/-/plugin-google-gtag-2.4.0.tgz",
+      "integrity": "sha512-adj/70DANaQs2+TF/nRdMezDXFAV/O/pjAbUgmKBlyOTq5qoMe0Tk4muvQIwWUmiUQxFJe+sKlZGM771ownyOg==",
       "requires": {
-        "@docusaurus/core": "2.3.1",
-        "@docusaurus/types": "2.3.1",
-        "@docusaurus/utils-validation": "2.3.1",
+        "@docusaurus/core": "2.4.0",
+        "@docusaurus/types": "2.4.0",
+        "@docusaurus/utils-validation": "2.4.0",
         "tslib": "^2.4.0"
-      },
-      "dependencies": {
-        "@docusaurus/core": {
-          "version": "2.3.1",
-          "resolved": "https://registry.npmjs.org/@docusaurus/core/-/core-2.3.1.tgz",
-          "integrity": "sha512-0Jd4jtizqnRAr7svWaBbbrCCN8mzBNd2xFLoT/IM7bGfFie5y58oz97KzXliwiLY3zWjqMXjQcuP1a5VgCv2JA==",
-          "requires": {
-            "@babel/core": "^7.18.6",
-            "@babel/generator": "^7.18.7",
-            "@babel/plugin-syntax-dynamic-import": "^7.8.3",
-            "@babel/plugin-transform-runtime": "^7.18.6",
-            "@babel/preset-env": "^7.18.6",
-            "@babel/preset-react": "^7.18.6",
-            "@babel/preset-typescript": "^7.18.6",
-            "@babel/runtime": "^7.18.6",
-            "@babel/runtime-corejs3": "^7.18.6",
-            "@babel/traverse": "^7.18.8",
-            "@docusaurus/cssnano-preset": "2.3.1",
-            "@docusaurus/logger": "2.3.1",
-            "@docusaurus/mdx-loader": "2.3.1",
-            "@docusaurus/react-loadable": "5.5.2",
-            "@docusaurus/utils": "2.3.1",
-            "@docusaurus/utils-common": "2.3.1",
-            "@docusaurus/utils-validation": "2.3.1",
-            "@slorber/static-site-generator-webpack-plugin": "^4.0.7",
-            "@svgr/webpack": "^6.2.1",
-            "autoprefixer": "^10.4.7",
-            "babel-loader": "^8.2.5",
-            "babel-plugin-dynamic-import-node": "^2.3.3",
-            "boxen": "^6.2.1",
-            "chalk": "^4.1.2",
-            "chokidar": "^3.5.3",
-            "clean-css": "^5.3.0",
-            "cli-table3": "^0.6.2",
-            "combine-promises": "^1.1.0",
-            "commander": "^5.1.0",
-            "copy-webpack-plugin": "^11.0.0",
-            "core-js": "^3.23.3",
-            "css-loader": "^6.7.1",
-            "css-minimizer-webpack-plugin": "^4.0.0",
-            "cssnano": "^5.1.12",
-            "del": "^6.1.1",
-            "detect-port": "^1.3.0",
-            "escape-html": "^1.0.3",
-            "eta": "^2.0.0",
-            "file-loader": "^6.2.0",
-            "fs-extra": "^10.1.0",
-            "html-minifier-terser": "^6.1.0",
-            "html-tags": "^3.2.0",
-            "html-webpack-plugin": "^5.5.0",
-            "import-fresh": "^3.3.0",
-            "leven": "^3.1.0",
-            "lodash": "^4.17.21",
-            "mini-css-extract-plugin": "^2.6.1",
-            "postcss": "^8.4.14",
-            "postcss-loader": "^7.0.0",
-            "prompts": "^2.4.2",
-            "react-dev-utils": "^12.0.1",
-            "react-helmet-async": "^1.3.0",
-            "react-loadable": "npm:@docusaurus/react-loadable@5.5.2",
-            "react-loadable-ssr-addon-v5-slorber": "^1.0.1",
-            "react-router": "^5.3.3",
-            "react-router-config": "^5.1.1",
-            "react-router-dom": "^5.3.3",
-            "rtl-detect": "^1.0.4",
-            "semver": "^7.3.7",
-            "serve-handler": "^6.1.3",
-            "shelljs": "^0.8.5",
-            "terser-webpack-plugin": "^5.3.3",
-            "tslib": "^2.4.0",
-            "update-notifier": "^5.1.0",
-            "url-loader": "^4.1.1",
-            "wait-on": "^6.0.1",
-            "webpack": "^5.73.0",
-            "webpack-bundle-analyzer": "^4.5.0",
-            "webpack-dev-server": "^4.9.3",
-            "webpack-merge": "^5.8.0",
-            "webpackbar": "^5.0.2"
-          }
-        },
-        "@docusaurus/cssnano-preset": {
-          "version": "2.3.1",
-          "resolved": "https://registry.npmjs.org/@docusaurus/cssnano-preset/-/cssnano-preset-2.3.1.tgz",
-          "integrity": "sha512-7mIhAROES6CY1GmCjR4CZkUfjTL6B3u6rKHK0ChQl2d1IevYXq/k/vFgvOrJfcKxiObpMnE9+X6R2Wt1KqxC6w==",
-          "requires": {
-            "cssnano-preset-advanced": "^5.3.8",
-            "postcss": "^8.4.14",
-            "postcss-sort-media-queries": "^4.2.1",
-            "tslib": "^2.4.0"
-          }
-        }
       }
     },
     "@docusaurus/plugin-google-tag-manager": {
-      "version": "2.3.1",
-      "resolved": "https://registry.npmjs.org/@docusaurus/plugin-google-tag-manager/-/plugin-google-tag-manager-2.3.1.tgz",
-      "integrity": "sha512-Ww2BPEYSqg8q8tJdLYPFFM3FMDBCVhEM4UUqKzJaiRMx3NEoly3qqDRAoRDGdIhlC//Rf0iJV9cWAoq2m6k3sw==",
+      "version": "2.4.0",
+      "resolved": "https://registry.npmjs.org/@docusaurus/plugin-google-tag-manager/-/plugin-google-tag-manager-2.4.0.tgz",
+      "integrity": "sha512-E66uGcYs4l7yitmp/8kMEVQftFPwV9iC62ORh47Veqzs6ExwnhzBkJmwDnwIysHBF1vlxnzET0Fl2LfL5fRR3A==",
       "requires": {
-        "@docusaurus/core": "2.3.1",
-        "@docusaurus/types": "2.3.1",
-        "@docusaurus/utils-validation": "2.3.1",
+        "@docusaurus/core": "2.4.0",
+        "@docusaurus/types": "2.4.0",
+        "@docusaurus/utils-validation": "2.4.0",
         "tslib": "^2.4.0"
-      },
-      "dependencies": {
-        "@docusaurus/core": {
-          "version": "2.3.1",
-          "resolved": "https://registry.npmjs.org/@docusaurus/core/-/core-2.3.1.tgz",
-          "integrity": "sha512-0Jd4jtizqnRAr7svWaBbbrCCN8mzBNd2xFLoT/IM7bGfFie5y58oz97KzXliwiLY3zWjqMXjQcuP1a5VgCv2JA==",
-          "requires": {
-            "@babel/core": "^7.18.6",
-            "@babel/generator": "^7.18.7",
-            "@babel/plugin-syntax-dynamic-import": "^7.8.3",
-            "@babel/plugin-transform-runtime": "^7.18.6",
-            "@babel/preset-env": "^7.18.6",
-            "@babel/preset-react": "^7.18.6",
-            "@babel/preset-typescript": "^7.18.6",
-            "@babel/runtime": "^7.18.6",
-            "@babel/runtime-corejs3": "^7.18.6",
-            "@babel/traverse": "^7.18.8",
-            "@docusaurus/cssnano-preset": "2.3.1",
-            "@docusaurus/logger": "2.3.1",
-            "@docusaurus/mdx-loader": "2.3.1",
-            "@docusaurus/react-loadable": "5.5.2",
-            "@docusaurus/utils": "2.3.1",
-            "@docusaurus/utils-common": "2.3.1",
-            "@docusaurus/utils-validation": "2.3.1",
-            "@slorber/static-site-generator-webpack-plugin": "^4.0.7",
-            "@svgr/webpack": "^6.2.1",
-            "autoprefixer": "^10.4.7",
-            "babel-loader": "^8.2.5",
-            "babel-plugin-dynamic-import-node": "^2.3.3",
-            "boxen": "^6.2.1",
-            "chalk": "^4.1.2",
-            "chokidar": "^3.5.3",
-            "clean-css": "^5.3.0",
-            "cli-table3": "^0.6.2",
-            "combine-promises": "^1.1.0",
-            "commander": "^5.1.0",
-            "copy-webpack-plugin": "^11.0.0",
-            "core-js": "^3.23.3",
-            "css-loader": "^6.7.1",
-            "css-minimizer-webpack-plugin": "^4.0.0",
-            "cssnano": "^5.1.12",
-            "del": "^6.1.1",
-            "detect-port": "^1.3.0",
-            "escape-html": "^1.0.3",
-            "eta": "^2.0.0",
-            "file-loader": "^6.2.0",
-            "fs-extra": "^10.1.0",
-            "html-minifier-terser": "^6.1.0",
-            "html-tags": "^3.2.0",
-            "html-webpack-plugin": "^5.5.0",
-            "import-fresh": "^3.3.0",
-            "leven": "^3.1.0",
-            "lodash": "^4.17.21",
-            "mini-css-extract-plugin": "^2.6.1",
-            "postcss": "^8.4.14",
-            "postcss-loader": "^7.0.0",
-            "prompts": "^2.4.2",
-            "react-dev-utils": "^12.0.1",
-            "react-helmet-async": "^1.3.0",
-            "react-loadable": "npm:@docusaurus/react-loadable@5.5.2",
-            "react-loadable-ssr-addon-v5-slorber": "^1.0.1",
-            "react-router": "^5.3.3",
-            "react-router-config": "^5.1.1",
-            "react-router-dom": "^5.3.3",
-            "rtl-detect": "^1.0.4",
-            "semver": "^7.3.7",
-            "serve-handler": "^6.1.3",
-            "shelljs": "^0.8.5",
-            "terser-webpack-plugin": "^5.3.3",
-            "tslib": "^2.4.0",
-            "update-notifier": "^5.1.0",
-            "url-loader": "^4.1.1",
-            "wait-on": "^6.0.1",
-            "webpack": "^5.73.0",
-            "webpack-bundle-analyzer": "^4.5.0",
-            "webpack-dev-server": "^4.9.3",
-            "webpack-merge": "^5.8.0",
-            "webpackbar": "^5.0.2"
-          }
-        },
-        "@docusaurus/cssnano-preset": {
-          "version": "2.3.1",
-          "resolved": "https://registry.npmjs.org/@docusaurus/cssnano-preset/-/cssnano-preset-2.3.1.tgz",
-          "integrity": "sha512-7mIhAROES6CY1GmCjR4CZkUfjTL6B3u6rKHK0ChQl2d1IevYXq/k/vFgvOrJfcKxiObpMnE9+X6R2Wt1KqxC6w==",
-          "requires": {
-            "cssnano-preset-advanced": "^5.3.8",
-            "postcss": "^8.4.14",
-            "postcss-sort-media-queries": "^4.2.1",
-            "tslib": "^2.4.0"
-          }
-        }
       }
     },
     "@docusaurus/plugin-sitemap": {
-      "version": "2.3.1",
-      "resolved": "https://registry.npmjs.org/@docusaurus/plugin-sitemap/-/plugin-sitemap-2.3.1.tgz",
-      "integrity": "sha512-8Yxile/v6QGYV9vgFiYL+8d2N4z4Er3pSHsrD08c5XI8bUXxTppMwjarDUTH/TRTfgAWotRbhJ6WZLyajLpozA==",
+      "version": "2.4.0",
+      "resolved": "https://registry.npmjs.org/@docusaurus/plugin-sitemap/-/plugin-sitemap-2.4.0.tgz",
+      "integrity": "sha512-pZxh+ygfnI657sN8a/FkYVIAmVv0CGk71QMKqJBOfMmDHNN1FeDeFkBjWP49ejBqpqAhjufkv5UWq3UOu2soCw==",
       "requires": {
-        "@docusaurus/core": "2.3.1",
-        "@docusaurus/logger": "2.3.1",
-        "@docusaurus/types": "2.3.1",
-        "@docusaurus/utils": "2.3.1",
-        "@docusaurus/utils-common": "2.3.1",
-        "@docusaurus/utils-validation": "2.3.1",
+        "@docusaurus/core": "2.4.0",
+        "@docusaurus/logger": "2.4.0",
+        "@docusaurus/types": "2.4.0",
+        "@docusaurus/utils": "2.4.0",
+        "@docusaurus/utils-common": "2.4.0",
+        "@docusaurus/utils-validation": "2.4.0",
         "fs-extra": "^10.1.0",
         "sitemap": "^7.1.1",
         "tslib": "^2.4.0"
-      },
-      "dependencies": {
-        "@docusaurus/core": {
-          "version": "2.3.1",
-          "resolved": "https://registry.npmjs.org/@docusaurus/core/-/core-2.3.1.tgz",
-          "integrity": "sha512-0Jd4jtizqnRAr7svWaBbbrCCN8mzBNd2xFLoT/IM7bGfFie5y58oz97KzXliwiLY3zWjqMXjQcuP1a5VgCv2JA==",
-          "requires": {
-            "@babel/core": "^7.18.6",
-            "@babel/generator": "^7.18.7",
-            "@babel/plugin-syntax-dynamic-import": "^7.8.3",
-            "@babel/plugin-transform-runtime": "^7.18.6",
-            "@babel/preset-env": "^7.18.6",
-            "@babel/preset-react": "^7.18.6",
-            "@babel/preset-typescript": "^7.18.6",
-            "@babel/runtime": "^7.18.6",
-            "@babel/runtime-corejs3": "^7.18.6",
-            "@babel/traverse": "^7.18.8",
-            "@docusaurus/cssnano-preset": "2.3.1",
-            "@docusaurus/logger": "2.3.1",
-            "@docusaurus/mdx-loader": "2.3.1",
-            "@docusaurus/react-loadable": "5.5.2",
-            "@docusaurus/utils": "2.3.1",
-            "@docusaurus/utils-common": "2.3.1",
-            "@docusaurus/utils-validation": "2.3.1",
-            "@slorber/static-site-generator-webpack-plugin": "^4.0.7",
-            "@svgr/webpack": "^6.2.1",
-            "autoprefixer": "^10.4.7",
-            "babel-loader": "^8.2.5",
-            "babel-plugin-dynamic-import-node": "^2.3.3",
-            "boxen": "^6.2.1",
-            "chalk": "^4.1.2",
-            "chokidar": "^3.5.3",
-            "clean-css": "^5.3.0",
-            "cli-table3": "^0.6.2",
-            "combine-promises": "^1.1.0",
-            "commander": "^5.1.0",
-            "copy-webpack-plugin": "^11.0.0",
-            "core-js": "^3.23.3",
-            "css-loader": "^6.7.1",
-            "css-minimizer-webpack-plugin": "^4.0.0",
-            "cssnano": "^5.1.12",
-            "del": "^6.1.1",
-            "detect-port": "^1.3.0",
-            "escape-html": "^1.0.3",
-            "eta": "^2.0.0",
-            "file-loader": "^6.2.0",
-            "fs-extra": "^10.1.0",
-            "html-minifier-terser": "^6.1.0",
-            "html-tags": "^3.2.0",
-            "html-webpack-plugin": "^5.5.0",
-            "import-fresh": "^3.3.0",
-            "leven": "^3.1.0",
-            "lodash": "^4.17.21",
-            "mini-css-extract-plugin": "^2.6.1",
-            "postcss": "^8.4.14",
-            "postcss-loader": "^7.0.0",
-            "prompts": "^2.4.2",
-            "react-dev-utils": "^12.0.1",
-            "react-helmet-async": "^1.3.0",
-            "react-loadable": "npm:@docusaurus/react-loadable@5.5.2",
-            "react-loadable-ssr-addon-v5-slorber": "^1.0.1",
-            "react-router": "^5.3.3",
-            "react-router-config": "^5.1.1",
-            "react-router-dom": "^5.3.3",
-            "rtl-detect": "^1.0.4",
-            "semver": "^7.3.7",
-            "serve-handler": "^6.1.3",
-            "shelljs": "^0.8.5",
-            "terser-webpack-plugin": "^5.3.3",
-            "tslib": "^2.4.0",
-            "update-notifier": "^5.1.0",
-            "url-loader": "^4.1.1",
-            "wait-on": "^6.0.1",
-            "webpack": "^5.73.0",
-            "webpack-bundle-analyzer": "^4.5.0",
-            "webpack-dev-server": "^4.9.3",
-            "webpack-merge": "^5.8.0",
-            "webpackbar": "^5.0.2"
-          }
-        },
-        "@docusaurus/cssnano-preset": {
-          "version": "2.3.1",
-          "resolved": "https://registry.npmjs.org/@docusaurus/cssnano-preset/-/cssnano-preset-2.3.1.tgz",
-          "integrity": "sha512-7mIhAROES6CY1GmCjR4CZkUfjTL6B3u6rKHK0ChQl2d1IevYXq/k/vFgvOrJfcKxiObpMnE9+X6R2Wt1KqxC6w==",
-          "requires": {
-            "cssnano-preset-advanced": "^5.3.8",
-            "postcss": "^8.4.14",
-            "postcss-sort-media-queries": "^4.2.1",
-            "tslib": "^2.4.0"
-          }
-        }
       }
     },
     "@docusaurus/preset-classic": {
-      "version": "2.3.1",
-      "resolved": "https://registry.npmjs.org/@docusaurus/preset-classic/-/preset-classic-2.3.1.tgz",
-      "integrity": "sha512-OQ5W0AHyfdUk0IldwJ3BlnZ1EqoJuu2L2BMhqLbqwNWdkmzmSUvlFLH1Pe7CZSQgB2YUUC/DnmjbPKk/qQD0lQ==",
+      "version": "2.4.0",
+      "resolved": "https://registry.npmjs.org/@docusaurus/preset-classic/-/preset-classic-2.4.0.tgz",
+      "integrity": "sha512-/5z5o/9bc6+P5ool2y01PbJhoGddEGsC0ej1MF6mCoazk8A+kW4feoUd68l7Bnv01rCnG3xy7kHUQP97Y0grUA==",
       "requires": {
-        "@docusaurus/core": "2.3.1",
-        "@docusaurus/plugin-content-blog": "2.3.1",
-        "@docusaurus/plugin-content-docs": "2.3.1",
-        "@docusaurus/plugin-content-pages": "2.3.1",
-        "@docusaurus/plugin-debug": "2.3.1",
-        "@docusaurus/plugin-google-analytics": "2.3.1",
-        "@docusaurus/plugin-google-gtag": "2.3.1",
-        "@docusaurus/plugin-google-tag-manager": "2.3.1",
-        "@docusaurus/plugin-sitemap": "2.3.1",
-        "@docusaurus/theme-classic": "2.3.1",
-        "@docusaurus/theme-common": "2.3.1",
-        "@docusaurus/theme-search-algolia": "2.3.1",
-        "@docusaurus/types": "2.3.1"
-      },
-      "dependencies": {
-        "@docusaurus/core": {
-          "version": "2.3.1",
-          "resolved": "https://registry.npmjs.org/@docusaurus/core/-/core-2.3.1.tgz",
-          "integrity": "sha512-0Jd4jtizqnRAr7svWaBbbrCCN8mzBNd2xFLoT/IM7bGfFie5y58oz97KzXliwiLY3zWjqMXjQcuP1a5VgCv2JA==",
-          "requires": {
-            "@babel/core": "^7.18.6",
-            "@babel/generator": "^7.18.7",
-            "@babel/plugin-syntax-dynamic-import": "^7.8.3",
-            "@babel/plugin-transform-runtime": "^7.18.6",
-            "@babel/preset-env": "^7.18.6",
-            "@babel/preset-react": "^7.18.6",
-            "@babel/preset-typescript": "^7.18.6",
-            "@babel/runtime": "^7.18.6",
-            "@babel/runtime-corejs3": "^7.18.6",
-            "@babel/traverse": "^7.18.8",
-            "@docusaurus/cssnano-preset": "2.3.1",
-            "@docusaurus/logger": "2.3.1",
-            "@docusaurus/mdx-loader": "2.3.1",
-            "@docusaurus/react-loadable": "5.5.2",
-            "@docusaurus/utils": "2.3.1",
-            "@docusaurus/utils-common": "2.3.1",
-            "@docusaurus/utils-validation": "2.3.1",
-            "@slorber/static-site-generator-webpack-plugin": "^4.0.7",
-            "@svgr/webpack": "^6.2.1",
-            "autoprefixer": "^10.4.7",
-            "babel-loader": "^8.2.5",
-            "babel-plugin-dynamic-import-node": "^2.3.3",
-            "boxen": "^6.2.1",
-            "chalk": "^4.1.2",
-            "chokidar": "^3.5.3",
-            "clean-css": "^5.3.0",
-            "cli-table3": "^0.6.2",
-            "combine-promises": "^1.1.0",
-            "commander": "^5.1.0",
-            "copy-webpack-plugin": "^11.0.0",
-            "core-js": "^3.23.3",
-            "css-loader": "^6.7.1",
-            "css-minimizer-webpack-plugin": "^4.0.0",
-            "cssnano": "^5.1.12",
-            "del": "^6.1.1",
-            "detect-port": "^1.3.0",
-            "escape-html": "^1.0.3",
-            "eta": "^2.0.0",
-            "file-loader": "^6.2.0",
-            "fs-extra": "^10.1.0",
-            "html-minifier-terser": "^6.1.0",
-            "html-tags": "^3.2.0",
-            "html-webpack-plugin": "^5.5.0",
-            "import-fresh": "^3.3.0",
-            "leven": "^3.1.0",
-            "lodash": "^4.17.21",
-            "mini-css-extract-plugin": "^2.6.1",
-            "postcss": "^8.4.14",
-            "postcss-loader": "^7.0.0",
-            "prompts": "^2.4.2",
-            "react-dev-utils": "^12.0.1",
-            "react-helmet-async": "^1.3.0",
-            "react-loadable": "npm:@docusaurus/react-loadable@5.5.2",
-            "react-loadable-ssr-addon-v5-slorber": "^1.0.1",
-            "react-router": "^5.3.3",
-            "react-router-config": "^5.1.1",
-            "react-router-dom": "^5.3.3",
-            "rtl-detect": "^1.0.4",
-            "semver": "^7.3.7",
-            "serve-handler": "^6.1.3",
-            "shelljs": "^0.8.5",
-            "terser-webpack-plugin": "^5.3.3",
-            "tslib": "^2.4.0",
-            "update-notifier": "^5.1.0",
-            "url-loader": "^4.1.1",
-            "wait-on": "^6.0.1",
-            "webpack": "^5.73.0",
-            "webpack-bundle-analyzer": "^4.5.0",
-            "webpack-dev-server": "^4.9.3",
-            "webpack-merge": "^5.8.0",
-            "webpackbar": "^5.0.2"
-          }
-        },
-        "@docusaurus/cssnano-preset": {
-          "version": "2.3.1",
-          "resolved": "https://registry.npmjs.org/@docusaurus/cssnano-preset/-/cssnano-preset-2.3.1.tgz",
-          "integrity": "sha512-7mIhAROES6CY1GmCjR4CZkUfjTL6B3u6rKHK0ChQl2d1IevYXq/k/vFgvOrJfcKxiObpMnE9+X6R2Wt1KqxC6w==",
-          "requires": {
-            "cssnano-preset-advanced": "^5.3.8",
-            "postcss": "^8.4.14",
-            "postcss-sort-media-queries": "^4.2.1",
-            "tslib": "^2.4.0"
-          }
-        }
+        "@docusaurus/core": "2.4.0",
+        "@docusaurus/plugin-content-blog": "2.4.0",
+        "@docusaurus/plugin-content-docs": "2.4.0",
+        "@docusaurus/plugin-content-pages": "2.4.0",
+        "@docusaurus/plugin-debug": "2.4.0",
+        "@docusaurus/plugin-google-analytics": "2.4.0",
+        "@docusaurus/plugin-google-gtag": "2.4.0",
+        "@docusaurus/plugin-google-tag-manager": "2.4.0",
+        "@docusaurus/plugin-sitemap": "2.4.0",
+        "@docusaurus/theme-classic": "2.4.0",
+        "@docusaurus/theme-common": "2.4.0",
+        "@docusaurus/theme-search-algolia": "2.4.0",
+        "@docusaurus/types": "2.4.0"
       }
     },
     "@docusaurus/react-loadable": {
@@ -16540,26 +14299,26 @@
       }
     },
     "@docusaurus/theme-classic": {
-      "version": "2.3.1",
-      "resolved": "https://registry.npmjs.org/@docusaurus/theme-classic/-/theme-classic-2.3.1.tgz",
-      "integrity": "sha512-SelSIDvyttb7ZYHj8vEUhqykhAqfOPKk+uP0z85jH72IMC58e7O8DIlcAeBv+CWsLbNIl9/Hcg71X0jazuxJug==",
+      "version": "2.4.0",
+      "resolved": "https://registry.npmjs.org/@docusaurus/theme-classic/-/theme-classic-2.4.0.tgz",
+      "integrity": "sha512-GMDX5WU6Z0OC65eQFgl3iNNEbI9IMJz9f6KnOyuMxNUR6q0qVLsKCNopFUDfFNJ55UU50o7P7o21yVhkwpfJ9w==",
       "requires": {
-        "@docusaurus/core": "2.3.1",
-        "@docusaurus/mdx-loader": "2.3.1",
-        "@docusaurus/module-type-aliases": "2.3.1",
-        "@docusaurus/plugin-content-blog": "2.3.1",
-        "@docusaurus/plugin-content-docs": "2.3.1",
-        "@docusaurus/plugin-content-pages": "2.3.1",
-        "@docusaurus/theme-common": "2.3.1",
-        "@docusaurus/theme-translations": "2.3.1",
-        "@docusaurus/types": "2.3.1",
-        "@docusaurus/utils": "2.3.1",
-        "@docusaurus/utils-common": "2.3.1",
-        "@docusaurus/utils-validation": "2.3.1",
+        "@docusaurus/core": "2.4.0",
+        "@docusaurus/mdx-loader": "2.4.0",
+        "@docusaurus/module-type-aliases": "2.4.0",
+        "@docusaurus/plugin-content-blog": "2.4.0",
+        "@docusaurus/plugin-content-docs": "2.4.0",
+        "@docusaurus/plugin-content-pages": "2.4.0",
+        "@docusaurus/theme-common": "2.4.0",
+        "@docusaurus/theme-translations": "2.4.0",
+        "@docusaurus/types": "2.4.0",
+        "@docusaurus/utils": "2.4.0",
+        "@docusaurus/utils-common": "2.4.0",
+        "@docusaurus/utils-validation": "2.4.0",
         "@mdx-js/react": "^1.6.22",
         "clsx": "^1.2.1",
         "copy-text-to-clipboard": "^3.0.1",
-        "infima": "0.2.0-alpha.42",
+        "infima": "0.2.0-alpha.43",
         "lodash": "^4.17.21",
         "nprogress": "^0.2.0",
         "postcss": "^8.4.14",
@@ -16569,125 +14328,20 @@
         "rtlcss": "^3.5.0",
         "tslib": "^2.4.0",
         "utility-types": "^3.10.0"
-      },
-      "dependencies": {
-        "@docusaurus/core": {
-          "version": "2.3.1",
-          "resolved": "https://registry.npmjs.org/@docusaurus/core/-/core-2.3.1.tgz",
-          "integrity": "sha512-0Jd4jtizqnRAr7svWaBbbrCCN8mzBNd2xFLoT/IM7bGfFie5y58oz97KzXliwiLY3zWjqMXjQcuP1a5VgCv2JA==",
-          "requires": {
-            "@babel/core": "^7.18.6",
-            "@babel/generator": "^7.18.7",
-            "@babel/plugin-syntax-dynamic-import": "^7.8.3",
-            "@babel/plugin-transform-runtime": "^7.18.6",
-            "@babel/preset-env": "^7.18.6",
-            "@babel/preset-react": "^7.18.6",
-            "@babel/preset-typescript": "^7.18.6",
-            "@babel/runtime": "^7.18.6",
-            "@babel/runtime-corejs3": "^7.18.6",
-            "@babel/traverse": "^7.18.8",
-            "@docusaurus/cssnano-preset": "2.3.1",
-            "@docusaurus/logger": "2.3.1",
-            "@docusaurus/mdx-loader": "2.3.1",
-            "@docusaurus/react-loadable": "5.5.2",
-            "@docusaurus/utils": "2.3.1",
-            "@docusaurus/utils-common": "2.3.1",
-            "@docusaurus/utils-validation": "2.3.1",
-            "@slorber/static-site-generator-webpack-plugin": "^4.0.7",
-            "@svgr/webpack": "^6.2.1",
-            "autoprefixer": "^10.4.7",
-            "babel-loader": "^8.2.5",
-            "babel-plugin-dynamic-import-node": "^2.3.3",
-            "boxen": "^6.2.1",
-            "chalk": "^4.1.2",
-            "chokidar": "^3.5.3",
-            "clean-css": "^5.3.0",
-            "cli-table3": "^0.6.2",
-            "combine-promises": "^1.1.0",
-            "commander": "^5.1.0",
-            "copy-webpack-plugin": "^11.0.0",
-            "core-js": "^3.23.3",
-            "css-loader": "^6.7.1",
-            "css-minimizer-webpack-plugin": "^4.0.0",
-            "cssnano": "^5.1.12",
-            "del": "^6.1.1",
-            "detect-port": "^1.3.0",
-            "escape-html": "^1.0.3",
-            "eta": "^2.0.0",
-            "file-loader": "^6.2.0",
-            "fs-extra": "^10.1.0",
-            "html-minifier-terser": "^6.1.0",
-            "html-tags": "^3.2.0",
-            "html-webpack-plugin": "^5.5.0",
-            "import-fresh": "^3.3.0",
-            "leven": "^3.1.0",
-            "lodash": "^4.17.21",
-            "mini-css-extract-plugin": "^2.6.1",
-            "postcss": "^8.4.14",
-            "postcss-loader": "^7.0.0",
-            "prompts": "^2.4.2",
-            "react-dev-utils": "^12.0.1",
-            "react-helmet-async": "^1.3.0",
-            "react-loadable": "npm:@docusaurus/react-loadable@5.5.2",
-            "react-loadable-ssr-addon-v5-slorber": "^1.0.1",
-            "react-router": "^5.3.3",
-            "react-router-config": "^5.1.1",
-            "react-router-dom": "^5.3.3",
-            "rtl-detect": "^1.0.4",
-            "semver": "^7.3.7",
-            "serve-handler": "^6.1.3",
-            "shelljs": "^0.8.5",
-            "terser-webpack-plugin": "^5.3.3",
-            "tslib": "^2.4.0",
-            "update-notifier": "^5.1.0",
-            "url-loader": "^4.1.1",
-            "wait-on": "^6.0.1",
-            "webpack": "^5.73.0",
-            "webpack-bundle-analyzer": "^4.5.0",
-            "webpack-dev-server": "^4.9.3",
-            "webpack-merge": "^5.8.0",
-            "webpackbar": "^5.0.2"
-          }
-        },
-        "@docusaurus/cssnano-preset": {
-          "version": "2.3.1",
-          "resolved": "https://registry.npmjs.org/@docusaurus/cssnano-preset/-/cssnano-preset-2.3.1.tgz",
-          "integrity": "sha512-7mIhAROES6CY1GmCjR4CZkUfjTL6B3u6rKHK0ChQl2d1IevYXq/k/vFgvOrJfcKxiObpMnE9+X6R2Wt1KqxC6w==",
-          "requires": {
-            "cssnano-preset-advanced": "^5.3.8",
-            "postcss": "^8.4.14",
-            "postcss-sort-media-queries": "^4.2.1",
-            "tslib": "^2.4.0"
-          }
-        },
-        "@docusaurus/module-type-aliases": {
-          "version": "2.3.1",
-          "resolved": "https://registry.npmjs.org/@docusaurus/module-type-aliases/-/module-type-aliases-2.3.1.tgz",
-          "integrity": "sha512-6KkxfAVOJqIUynTRb/tphYCl+co3cP0PlHiMDbi+SzmYxMdgIrwYqH9yAnGSDoN6Jk2ZE/JY/Azs/8LPgKP48A==",
-          "requires": {
-            "@docusaurus/react-loadable": "5.5.2",
-            "@docusaurus/types": "2.3.1",
-            "@types/history": "^4.7.11",
-            "@types/react": "*",
-            "@types/react-router-config": "*",
-            "@types/react-router-dom": "*",
-            "react-helmet-async": "*",
-            "react-loadable": "npm:@docusaurus/react-loadable@5.5.2"
-          }
-        }
       }
     },
     "@docusaurus/theme-common": {
-      "version": "2.3.1",
-      "resolved": "https://registry.npmjs.org/@docusaurus/theme-common/-/theme-common-2.3.1.tgz",
-      "integrity": "sha512-RYmYl2OR2biO+yhmW1aS5FyEvnrItPINa+0U2dMxcHpah8reSCjQ9eJGRmAgkZFchV1+aIQzXOI1K7LCW38O0g==",
+      "version": "2.4.0",
+      "resolved": "https://registry.npmjs.org/@docusaurus/theme-common/-/theme-common-2.4.0.tgz",
+      "integrity": "sha512-IkG/l5f/FLY6cBIxtPmFnxpuPzc5TupuqlOx+XDN+035MdQcAh8wHXXZJAkTeYDeZ3anIUSUIvWa7/nRKoQEfg==",
       "requires": {
-        "@docusaurus/mdx-loader": "2.3.1",
-        "@docusaurus/module-type-aliases": "2.3.1",
-        "@docusaurus/plugin-content-blog": "2.3.1",
-        "@docusaurus/plugin-content-docs": "2.3.1",
-        "@docusaurus/plugin-content-pages": "2.3.1",
-        "@docusaurus/utils": "2.3.1",
+        "@docusaurus/mdx-loader": "2.4.0",
+        "@docusaurus/module-type-aliases": "2.4.0",
+        "@docusaurus/plugin-content-blog": "2.4.0",
+        "@docusaurus/plugin-content-docs": "2.4.0",
+        "@docusaurus/plugin-content-pages": "2.4.0",
+        "@docusaurus/utils": "2.4.0",
+        "@docusaurus/utils-common": "2.4.0",
         "@types/history": "^4.7.11",
         "@types/react": "*",
         "@types/react-router-config": "*",
@@ -16697,38 +14351,21 @@
         "tslib": "^2.4.0",
         "use-sync-external-store": "^1.2.0",
         "utility-types": "^3.10.0"
-      },
-      "dependencies": {
-        "@docusaurus/module-type-aliases": {
-          "version": "2.3.1",
-          "resolved": "https://registry.npmjs.org/@docusaurus/module-type-aliases/-/module-type-aliases-2.3.1.tgz",
-          "integrity": "sha512-6KkxfAVOJqIUynTRb/tphYCl+co3cP0PlHiMDbi+SzmYxMdgIrwYqH9yAnGSDoN6Jk2ZE/JY/Azs/8LPgKP48A==",
-          "requires": {
-            "@docusaurus/react-loadable": "5.5.2",
-            "@docusaurus/types": "2.3.1",
-            "@types/history": "^4.7.11",
-            "@types/react": "*",
-            "@types/react-router-config": "*",
-            "@types/react-router-dom": "*",
-            "react-helmet-async": "*",
-            "react-loadable": "npm:@docusaurus/react-loadable@5.5.2"
-          }
-        }
       }
     },
     "@docusaurus/theme-search-algolia": {
-      "version": "2.3.1",
-      "resolved": "https://registry.npmjs.org/@docusaurus/theme-search-algolia/-/theme-search-algolia-2.3.1.tgz",
-      "integrity": "sha512-JdHaRqRuH1X++g5fEMLnq7OtULSGQdrs9AbhcWRQ428ZB8/HOiaN6mj3hzHvcD3DFgu7koIVtWPQnvnN7iwzHA==",
+      "version": "2.4.0",
+      "resolved": "https://registry.npmjs.org/@docusaurus/theme-search-algolia/-/theme-search-algolia-2.4.0.tgz",
+      "integrity": "sha512-pPCJSCL1Qt4pu/Z0uxBAuke0yEBbxh0s4fOvimna7TEcBLPq0x06/K78AaABXrTVQM6S0vdocFl9EoNgU17hqA==",
       "requires": {
         "@docsearch/react": "^3.1.1",
-        "@docusaurus/core": "2.3.1",
-        "@docusaurus/logger": "2.3.1",
-        "@docusaurus/plugin-content-docs": "2.3.1",
-        "@docusaurus/theme-common": "2.3.1",
-        "@docusaurus/theme-translations": "2.3.1",
-        "@docusaurus/utils": "2.3.1",
-        "@docusaurus/utils-validation": "2.3.1",
+        "@docusaurus/core": "2.4.0",
+        "@docusaurus/logger": "2.4.0",
+        "@docusaurus/plugin-content-docs": "2.4.0",
+        "@docusaurus/theme-common": "2.4.0",
+        "@docusaurus/theme-translations": "2.4.0",
+        "@docusaurus/utils": "2.4.0",
+        "@docusaurus/utils-validation": "2.4.0",
         "algoliasearch": "^4.13.1",
         "algoliasearch-helper": "^3.10.0",
         "clsx": "^1.2.1",
@@ -16737,112 +14374,21 @@
         "lodash": "^4.17.21",
         "tslib": "^2.4.0",
         "utility-types": "^3.10.0"
-      },
-      "dependencies": {
-        "@docusaurus/core": {
-          "version": "2.3.1",
-          "resolved": "https://registry.npmjs.org/@docusaurus/core/-/core-2.3.1.tgz",
-          "integrity": "sha512-0Jd4jtizqnRAr7svWaBbbrCCN8mzBNd2xFLoT/IM7bGfFie5y58oz97KzXliwiLY3zWjqMXjQcuP1a5VgCv2JA==",
-          "requires": {
-            "@babel/core": "^7.18.6",
-            "@babel/generator": "^7.18.7",
-            "@babel/plugin-syntax-dynamic-import": "^7.8.3",
-            "@babel/plugin-transform-runtime": "^7.18.6",
-            "@babel/preset-env": "^7.18.6",
-            "@babel/preset-react": "^7.18.6",
-            "@babel/preset-typescript": "^7.18.6",
-            "@babel/runtime": "^7.18.6",
-            "@babel/runtime-corejs3": "^7.18.6",
-            "@babel/traverse": "^7.18.8",
-            "@docusaurus/cssnano-preset": "2.3.1",
-            "@docusaurus/logger": "2.3.1",
-            "@docusaurus/mdx-loader": "2.3.1",
-            "@docusaurus/react-loadable": "5.5.2",
-            "@docusaurus/utils": "2.3.1",
-            "@docusaurus/utils-common": "2.3.1",
-            "@docusaurus/utils-validation": "2.3.1",
-            "@slorber/static-site-generator-webpack-plugin": "^4.0.7",
-            "@svgr/webpack": "^6.2.1",
-            "autoprefixer": "^10.4.7",
-            "babel-loader": "^8.2.5",
-            "babel-plugin-dynamic-import-node": "^2.3.3",
-            "boxen": "^6.2.1",
-            "chalk": "^4.1.2",
-            "chokidar": "^3.5.3",
-            "clean-css": "^5.3.0",
-            "cli-table3": "^0.6.2",
-            "combine-promises": "^1.1.0",
-            "commander": "^5.1.0",
-            "copy-webpack-plugin": "^11.0.0",
-            "core-js": "^3.23.3",
-            "css-loader": "^6.7.1",
-            "css-minimizer-webpack-plugin": "^4.0.0",
-            "cssnano": "^5.1.12",
-            "del": "^6.1.1",
-            "detect-port": "^1.3.0",
-            "escape-html": "^1.0.3",
-            "eta": "^2.0.0",
-            "file-loader": "^6.2.0",
-            "fs-extra": "^10.1.0",
-            "html-minifier-terser": "^6.1.0",
-            "html-tags": "^3.2.0",
-            "html-webpack-plugin": "^5.5.0",
-            "import-fresh": "^3.3.0",
-            "leven": "^3.1.0",
-            "lodash": "^4.17.21",
-            "mini-css-extract-plugin": "^2.6.1",
-            "postcss": "^8.4.14",
-            "postcss-loader": "^7.0.0",
-            "prompts": "^2.4.2",
-            "react-dev-utils": "^12.0.1",
-            "react-helmet-async": "^1.3.0",
-            "react-loadable": "npm:@docusaurus/react-loadable@5.5.2",
-            "react-loadable-ssr-addon-v5-slorber": "^1.0.1",
-            "react-router": "^5.3.3",
-            "react-router-config": "^5.1.1",
-            "react-router-dom": "^5.3.3",
-            "rtl-detect": "^1.0.4",
-            "semver": "^7.3.7",
-            "serve-handler": "^6.1.3",
-            "shelljs": "^0.8.5",
-            "terser-webpack-plugin": "^5.3.3",
-            "tslib": "^2.4.0",
-            "update-notifier": "^5.1.0",
-            "url-loader": "^4.1.1",
-            "wait-on": "^6.0.1",
-            "webpack": "^5.73.0",
-            "webpack-bundle-analyzer": "^4.5.0",
-            "webpack-dev-server": "^4.9.3",
-            "webpack-merge": "^5.8.0",
-            "webpackbar": "^5.0.2"
-          }
-        },
-        "@docusaurus/cssnano-preset": {
-          "version": "2.3.1",
-          "resolved": "https://registry.npmjs.org/@docusaurus/cssnano-preset/-/cssnano-preset-2.3.1.tgz",
-          "integrity": "sha512-7mIhAROES6CY1GmCjR4CZkUfjTL6B3u6rKHK0ChQl2d1IevYXq/k/vFgvOrJfcKxiObpMnE9+X6R2Wt1KqxC6w==",
-          "requires": {
-            "cssnano-preset-advanced": "^5.3.8",
-            "postcss": "^8.4.14",
-            "postcss-sort-media-queries": "^4.2.1",
-            "tslib": "^2.4.0"
-          }
-        }
       }
     },
     "@docusaurus/theme-translations": {
-      "version": "2.3.1",
-      "resolved": "https://registry.npmjs.org/@docusaurus/theme-translations/-/theme-translations-2.3.1.tgz",
-      "integrity": "sha512-BsBZzAewJabVhoGG1Ij2u4pMS3MPW6gZ6sS4pc+Y7czevRpzxoFNJXRtQDVGe7mOpv/MmRmqg4owDK+lcOTCVQ==",
+      "version": "2.4.0",
+      "resolved": "https://registry.npmjs.org/@docusaurus/theme-translations/-/theme-translations-2.4.0.tgz",
+      "integrity": "sha512-kEoITnPXzDPUMBHk3+fzEzbopxLD3fR5sDoayNH0vXkpUukA88/aDL1bqkhxWZHA3LOfJ3f0vJbOwmnXW5v85Q==",
       "requires": {
         "fs-extra": "^10.1.0",
         "tslib": "^2.4.0"
       }
     },
     "@docusaurus/types": {
-      "version": "2.3.1",
-      "resolved": "https://registry.npmjs.org/@docusaurus/types/-/types-2.3.1.tgz",
-      "integrity": "sha512-PREbIRhTaNNY042qmfSE372Jb7djZt+oVTZkoqHJ8eff8vOIc2zqqDqBVc5BhOfpZGPTrE078yy/torUEZy08A==",
+      "version": "2.4.0",
+      "resolved": "https://registry.npmjs.org/@docusaurus/types/-/types-2.4.0.tgz",
+      "integrity": "sha512-xaBXr+KIPDkIaef06c+i2HeTqVNixB7yFut5fBXPGI2f1rrmEV2vLMznNGsFwvZ5XmA3Quuefd4OGRkdo97Dhw==",
       "requires": {
         "@types/history": "^4.7.11",
         "@types/react": "*",
@@ -16855,11 +14401,11 @@
       }
     },
     "@docusaurus/utils": {
-      "version": "2.3.1",
-      "resolved": "https://registry.npmjs.org/@docusaurus/utils/-/utils-2.3.1.tgz",
-      "integrity": "sha512-9WcQROCV0MmrpOQDXDGhtGMd52DHpSFbKLfkyaYumzbTstrbA5pPOtiGtxK1nqUHkiIv8UwexS54p0Vod2I1lg==",
+      "version": "2.4.0",
+      "resolved": "https://registry.npmjs.org/@docusaurus/utils/-/utils-2.4.0.tgz",
+      "integrity": "sha512-89hLYkvtRX92j+C+ERYTuSUK6nF9bGM32QThcHPg2EDDHVw6FzYQXmX6/p+pU5SDyyx5nBlE4qXR92RxCAOqfg==",
       "requires": {
-        "@docusaurus/logger": "2.3.1",
+        "@docusaurus/logger": "2.4.0",
         "@svgr/webpack": "^6.2.1",
         "escape-string-regexp": "^4.0.0",
         "file-loader": "^6.2.0",
@@ -16878,20 +14424,20 @@
       }
     },
     "@docusaurus/utils-common": {
-      "version": "2.3.1",
-      "resolved": "https://registry.npmjs.org/@docusaurus/utils-common/-/utils-common-2.3.1.tgz",
-      "integrity": "sha512-pVlRpXkdNcxmKNxAaB1ya2hfCEvVsLDp2joeM6K6uv55Oc5nVIqgyYSgSNKZyMdw66NnvMfsu0RBylcwZQKo9A==",
+      "version": "2.4.0",
+      "resolved": "https://registry.npmjs.org/@docusaurus/utils-common/-/utils-common-2.4.0.tgz",
+      "integrity": "sha512-zIMf10xuKxddYfLg5cS19x44zud/E9I7lj3+0bv8UIs0aahpErfNrGhijEfJpAfikhQ8tL3m35nH3hJ3sOG82A==",
       "requires": {
         "tslib": "^2.4.0"
       }
     },
     "@docusaurus/utils-validation": {
-      "version": "2.3.1",
-      "resolved": "https://registry.npmjs.org/@docusaurus/utils-validation/-/utils-validation-2.3.1.tgz",
-      "integrity": "sha512-7n0208IG3k1HVTByMHlZoIDjjOFC8sbViHVXJx0r3Q+3Ezrx+VQ1RZ/zjNn6lT+QBCRCXlnlaoJ8ug4HIVgQ3w==",
+      "version": "2.4.0",
+      "resolved": "https://registry.npmjs.org/@docusaurus/utils-validation/-/utils-validation-2.4.0.tgz",
+      "integrity": "sha512-IrBsBbbAp6y7mZdJx4S4pIA7dUyWSA0GNosPk6ZJ0fX3uYIEQgcQSGIgTeSC+8xPEx3c16o03en1jSDpgQgz/w==",
       "requires": {
-        "@docusaurus/logger": "2.3.1",
-        "@docusaurus/utils": "2.3.1",
+        "@docusaurus/logger": "2.4.0",
+        "@docusaurus/utils": "2.4.0",
         "joi": "^17.6.0",
         "js-yaml": "^4.1.0",
         "tslib": "^2.4.0"
@@ -17807,30 +15353,30 @@
       "requires": {}
     },
     "algoliasearch": {
-      "version": "4.14.3",
-      "resolved": "https://registry.npmjs.org/algoliasearch/-/algoliasearch-4.14.3.tgz",
-      "integrity": "sha512-GZTEuxzfWbP/vr7ZJfGzIl8fOsoxN916Z6FY2Egc9q2TmZ6hvq5KfAxY89pPW01oW/2HDEKA8d30f9iAH9eXYg==",
+      "version": "4.16.0",
+      "resolved": "https://registry.npmjs.org/algoliasearch/-/algoliasearch-4.16.0.tgz",
+      "integrity": "sha512-HAjKJ6bBblaXqO4dYygF4qx251GuJ6zCZt+qbJ+kU7sOC+yc84pawEjVpJByh+cGP2APFCsao2Giz50cDlKNPA==",
       "requires": {
-        "@algolia/cache-browser-local-storage": "4.14.3",
-        "@algolia/cache-common": "4.14.3",
-        "@algolia/cache-in-memory": "4.14.3",
-        "@algolia/client-account": "4.14.3",
-        "@algolia/client-analytics": "4.14.3",
-        "@algolia/client-common": "4.14.3",
-        "@algolia/client-personalization": "4.14.3",
-        "@algolia/client-search": "4.14.3",
-        "@algolia/logger-common": "4.14.3",
-        "@algolia/logger-console": "4.14.3",
-        "@algolia/requester-browser-xhr": "4.14.3",
-        "@algolia/requester-common": "4.14.3",
-        "@algolia/requester-node-http": "4.14.3",
-        "@algolia/transporter": "4.14.3"
+        "@algolia/cache-browser-local-storage": "4.16.0",
+        "@algolia/cache-common": "4.16.0",
+        "@algolia/cache-in-memory": "4.16.0",
+        "@algolia/client-account": "4.16.0",
+        "@algolia/client-analytics": "4.16.0",
+        "@algolia/client-common": "4.16.0",
+        "@algolia/client-personalization": "4.16.0",
+        "@algolia/client-search": "4.16.0",
+        "@algolia/logger-common": "4.16.0",
+        "@algolia/logger-console": "4.16.0",
+        "@algolia/requester-browser-xhr": "4.16.0",
+        "@algolia/requester-common": "4.16.0",
+        "@algolia/requester-node-http": "4.16.0",
+        "@algolia/transporter": "4.16.0"
       }
     },
     "algoliasearch-helper": {
-      "version": "3.11.3",
-      "resolved": "https://registry.npmjs.org/algoliasearch-helper/-/algoliasearch-helper-3.11.3.tgz",
-      "integrity": "sha512-TbaEvLwiuGygHQIB8y+OsJKQQ40+JKUua5B91X66tMUHyyhbNHvqyr0lqd3wCoyKx7WybyQrC0WJvzoIeh24Aw==",
+      "version": "3.12.0",
+      "resolved": "https://registry.npmjs.org/algoliasearch-helper/-/algoliasearch-helper-3.12.0.tgz",
+      "integrity": "sha512-/j1U3PEwdan0n6P/QqSnSpNSLC5+cEMvyljd5CnmNmUjDlGrys+vFEOwjVEnqELIiAGMHEA/Nl3CiKVFBUYqyQ==",
       "requires": {
         "@algolia/events": "^4.0.1"
       }
@@ -18571,9 +16117,9 @@
       "integrity": "sha512-QADzlaHc8icV8I7vbaJXJwod9HWYp8uCqf1xa4OfNu1T7JVxQIrUgOWtHdNDtPiywmFbiS12VjotIXLrKM3orQ=="
     },
     "copy-text-to-clipboard": {
-      "version": "3.0.1",
-      "resolved": "https://registry.npmjs.org/copy-text-to-clipboard/-/copy-text-to-clipboard-3.0.1.tgz",
-      "integrity": "sha512-rvVsHrpFcL4F2P8ihsoLdFHmd404+CMg71S756oRSeQgqk51U3kicGdnvfkrxva0xXH92SjGS62B0XIJsbh+9Q=="
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/copy-text-to-clipboard/-/copy-text-to-clipboard-3.1.0.tgz",
+      "integrity": "sha512-PFM6BnjLnOON/lB3ta/Jg7Ywsv+l9kQGD4TWDCSlRBGmqnnTM5MrDkhAFgw+8HZt0wW6Q2BBE4cmy9sq+s9Qng=="
     },
     "copy-webpack-plugin": {
       "version": "11.0.0",
@@ -19556,9 +17102,9 @@
       }
     },
     "flux": {
-      "version": "4.0.3",
-      "resolved": "https://registry.npmjs.org/flux/-/flux-4.0.3.tgz",
-      "integrity": "sha512-yKAbrp7JhZhj6uiT1FTuVMlIAT1J4jqEyBpFApi1kxpGZCvacMVc/t1pMQyotqHhAgvoE3bNvAykhCo2CLjnYw==",
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/flux/-/flux-4.0.4.tgz",
+      "integrity": "sha512-NCj3XlayA2UsapRpM7va6wU1+9rE5FIL7qoMcmxWHRzbp0yujihMBm9BBHZ1MDIk5h5o2Bl6eGiCe8rYELAmYw==",
       "requires": {
         "fbemitter": "^3.0.0",
         "fbjs": "^3.0.1"
@@ -20087,14 +17633,14 @@
       }
     },
     "htmlparser2": {
-      "version": "8.0.1",
-      "resolved": "https://registry.npmjs.org/htmlparser2/-/htmlparser2-8.0.1.tgz",
-      "integrity": "sha512-4lVbmc1diZC7GUJQtRQ5yBAeUCL1exyMwmForWkRLnwyzWBFxN633SALPMGYaWZvKe9j1pRZJpauvmxENSp/EA==",
+      "version": "8.0.2",
+      "resolved": "https://registry.npmjs.org/htmlparser2/-/htmlparser2-8.0.2.tgz",
+      "integrity": "sha512-GYdjWKDkbRLkZ5geuHs5NY1puJ+PXwP7+fHPRz06Eirsb9ugf6d8kkXav6ADhcODhFFPMIXyxkxSuMf3D6NCFA==",
       "requires": {
         "domelementtype": "^2.3.0",
-        "domhandler": "^5.0.2",
+        "domhandler": "^5.0.3",
         "domutils": "^3.0.1",
-        "entities": "^4.3.0"
+        "entities": "^4.4.0"
       }
     },
     "http-cache-semantics": {
@@ -20215,9 +17761,9 @@
       "integrity": "sha512-EdDDZu4A2OyIK7Lr/2zG+w5jmbuk1DVBnEwREQvBzspBJkCEbRa8GxU1lghYcaGJCnRWibjDXlq779X1/y5xwg=="
     },
     "infima": {
-      "version": "0.2.0-alpha.42",
-      "resolved": "https://registry.npmjs.org/infima/-/infima-0.2.0-alpha.42.tgz",
-      "integrity": "sha512-ift8OXNbQQwtbIt6z16KnSWP7uJ/SysSMFI4F87MNRTicypfl4Pv3E2OGVv6N3nSZFJvA8imYulCBS64iyHYww=="
+      "version": "0.2.0-alpha.43",
+      "resolved": "https://registry.npmjs.org/infima/-/infima-0.2.0-alpha.43.tgz",
+      "integrity": "sha512-2uw57LvUqW0rK/SWYnd/2rRfxNA5DDNOh33jxF7fy46VWoNhGxiUQyVZHbBMjQ33mQem0cjdDVwgWVAmlRfgyQ=="
     },
     "inflight": {
       "version": "1.0.6",
@@ -22079,11 +19625,11 @@
       }
     },
     "react-textarea-autosize": {
-      "version": "8.4.0",
-      "resolved": "https://registry.npmjs.org/react-textarea-autosize/-/react-textarea-autosize-8.4.0.tgz",
-      "integrity": "sha512-YrTFaEHLgJsi8sJVYHBzYn+mkP3prGkmP2DKb/tm0t7CLJY5t1Rxix8070LAKb0wby7bl/lf2EeHkuMihMZMwQ==",
+      "version": "8.4.1",
+      "resolved": "https://registry.npmjs.org/react-textarea-autosize/-/react-textarea-autosize-8.4.1.tgz",
+      "integrity": "sha512-aD2C+qK6QypknC+lCMzteOdIjoMbNlgSFmJjCV+DrfTPwp59i/it9mMNf2HDzvRjQgKAyBDPyLJhcrzElf2U4Q==",
       "requires": {
-        "@babel/runtime": "^7.10.2",
+        "@babel/runtime": "^7.20.13",
         "use-composed-ref": "^1.3.0",
         "use-latest": "^1.2.1"
       }
@@ -22175,9 +19721,9 @@
       }
     },
     "regenerator-runtime": {
-      "version": "0.13.9",
-      "resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.13.9.tgz",
-      "integrity": "sha512-p3VT+cOEgxFsRRA9X4lkI1E+k2/CtnKtU4gcxyaCUreilL/vqI6CdZ3wxVUx3UOUg+gnUOQQcRI7BmSI656MYA=="
+      "version": "0.13.11",
+      "resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.13.11.tgz",
+      "integrity": "sha512-kY1AZVr2Ra+t+piVaJ4gxaFaReZVH40AKNo7UCX6W+dEwBo/2oZJzqfuN1qLq1oL45o56cPaTXELwrTh8Fpggg=="
     },
     "regenerator-transform": {
       "version": "0.15.0",
@@ -23351,9 +20897,9 @@
       "integrity": "sha512-1FXk9E2Hm+QzZQ7z+McJiHL4NW1F2EzMu9Nq9i3zAaGqibafqYwCVU6WyWAuyQRRzOlxou8xZSyXLEN8oKj24g=="
     },
     "ua-parser-js": {
-      "version": "0.7.33",
-      "resolved": "https://registry.npmjs.org/ua-parser-js/-/ua-parser-js-0.7.33.tgz",
-      "integrity": "sha512-s8ax/CeZdK9R/56Sui0WM6y9OFREJarMRHqLB2EwkovemBxNQ+Bqu8GAsUnVcXKgphb++ghr/B2BZx4mahujPw=="
+      "version": "0.7.34",
+      "resolved": "https://registry.npmjs.org/ua-parser-js/-/ua-parser-js-0.7.34.tgz",
+      "integrity": "sha512-cJMeh/eOILyGu0ejgTKB95yKT3zOenSe9UGE3vj6WfiOwgGYnmATUsnDixMFvdU+rNMvWih83hrUP8VwhF9yXQ=="
     },
     "unherit": {
       "version": "1.1.3",

--- a/docs/package.json
+++ b/docs/package.json
@@ -16,7 +16,7 @@
   },
   "dependencies": {
     "@docusaurus/core": "2.4.0",
-    "@docusaurus/preset-classic": "2.3.1",
+    "@docusaurus/preset-classic": "2.4.0",
     "@mdx-js/react": "^1.6.22",
     "clsx": "^1.2.1",
     "prism-react-renderer": "^1.3.5",


### PR DESCRIPTION

Update(docs): bump @docusaurus/preset-classic in /docs

Bumps [@docusaurus/preset-classic](https://github.com/facebook/docusaurus/tree/HEAD/packages/docusaurus-preset-classic) from 2.3.1 to 2.4.0.
- [Release notes](https://github.com/facebook/docusaurus/releases)
- [Changelog](https://github.com/facebook/docusaurus/blob/main/CHANGELOG.md)
- [Commits](https://github.com/facebook/docusaurus/commits/v2.4.0/packages/docusaurus-preset-classic)

---
updated-dependencies:
- dependency-name: "@docusaurus/preset-classic" dependency-type: direct:production update-type: version-update:semver-minor ...