### PR TITLE
Fix: update last check datetime on downloading a binary

### DIFF
--- a/src/Component/BinaryManager.ts
+++ b/src/Component/BinaryManager.ts
@@ -137,6 +137,7 @@ export class BinaryManager extends LogEmitter {
           "close",
         )
       ]);
+      this.lastChecked = Date.now();
       this.Log("Finish downloading the binary");
     }
   }


### PR DESCRIPTION
(cherry picked from commit 9ae77ad204f94ec9beae74e309640857402615d8)