### PR TITLE
Fix: dependabot

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -93,16 +93,3 @@ updates:
       - "dependencies"
       - "github_actions"
 
-  # actions (v3)
-  - package-ecosystem: github-actions
-    directory: "/"
-    schedule:
-      interval: "daily"
-      time: "09:00"
-      timezone: "Asia/Tokyo"
-    commit-message:
-      prefix: "Update(action):"
-    target-branch: "v3"
-    labels:
-      - "dependencies"
-      - "github_actions"


### PR DESCRIPTION
Only actions in default branch works,
so update actions in v3 is unnecessary.