### PR TITLE
Chore(dependabot.yml): ignore major updates of i18next

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -25,6 +25,9 @@ updates:
       - dependency-name: "p-event"
         update-types:
           - "version-update:semver-major"
+      - dependency-name: "i18next"
+        update-types:
+          - "version-update:semver-major"
 
   # v3 branch
   - package-ecosystem: npm


### PR DESCRIPTION
i18next's next major version doesn't support non-strict typescript