### PR TITLE
Fix: too heavy logs in one entry

### DIFF
--- a/src/Commands/log.ts
+++ b/src/Commands/log.ts
@@ -117,7 +117,7 @@ export default class SystemInfo extends BaseCommand {
       let logs: string[] = [...getLogs()];
       logs.reverse();
       for(let i = 0; i < logs.length; i++){
-        if(logs.join("\r\n").length < 1950) break;
+        if(logs.join("\r\n").length < 3950) break;
         logs = logs.slice(0, -1);
       }
       logs.reverse();
@@ -225,7 +225,7 @@ export default class SystemInfo extends BaseCommand {
           .toOceanic()
       );
     }
-    
+
     if(embeds.length > 0){
       await message.channel.createMessage({ embeds }).catch(this.logger.error);
     }

--- a/src/botBase.ts
+++ b/src/botBase.ts
@@ -24,7 +24,6 @@ import type * as discord from "oceanic.js";
 import { execSync } from "child_process";
 import fs from "fs";
 import path from "path";
-import util from "util";
 
 import { RateLimitController } from "./Component/RateLimitController";
 import { SourceCache } from "./Component/SourceCache";
@@ -222,9 +221,6 @@ export abstract class MusicBotBase extends LogEmitter<BotBaseEvents> {
     this.logger.info(
       `[Tick] (System) Memory RSS: ${rss}MB, Heap total: ${Util.system.getMBytes(nMem.heapTotal)}MB, Total: ${Util.getPercentage(rss + ext, memory.total)}%`
     );
-
-    // for debug purpose
-    this.logger.trace("ratelimits", util.inspect(this.client.rest.handler.ratelimits, { showHidden: true, depth: Infinity }));
   }
 
   abstract run(debugLog: boolean, debugLogStoreLength?: number): void;


### PR DESCRIPTION
* The temporary logging for debugging purpose had caused the log command broken.
* The rate-limiting bug was fixed by oceanic's upstream and the logging is no longer needed.
* fix #1692 