### PR TITLE
Fix: fatal error handling

### DIFF
--- a/src/Component/telemetry.ts
+++ b/src/Component/telemetry.ts
@@ -56,11 +56,15 @@ export class Telemetry extends LogEmitter<Record<never, never>> {
     this._paused = false;
   }
 
+  registerError(err: unknown){
+    this.errors.push(stringifyObject(err));
+  }
+
   private onReady(){
     this.send().catch(this.logger.warn);
     this.bot.on("tick", this.onTick.bind(this));
     process.on("uncaughtException", err => {
-      this.errors.push(stringifyObject(err));
+      this.registerError(err);
     });
   }
 

--- a/src/config/index.ts
+++ b/src/config/index.ts
@@ -74,20 +74,26 @@ class ConfigLoader {
   protected load(){
     const checker = TypeCompiler.Compile(ConfigSchema);
 
-    const config = CJSON.parse(
-      fs.readFileSync(path.join(__dirname, global.BUNDLED ? "../config.json" : "../../config.json"), { encoding: "utf-8" }),
-      undefined,
-      true
-    );
+    let config: ReturnType<typeof CJSON.parse> = null;
+
+    try{
+      config = CJSON.parse(
+        fs.readFileSync(path.join(__dirname, global.BUNDLED ? "../config.json" : "../../config.json"), { encoding: "utf-8" }),
+        undefined,
+        true
+      );
+    }
+    catch(er){
+      throw new Error("Failed to parse `config.json`.", {
+        cause: er,
+      });
+    }
 
     const errs = [...checker.Errors(config)];
     if(errs.length > 0){
-      const er = new Error("Invalid config.json");
-      console.log(errs);
-      Object.defineProperty(er, "errors", {
-        value: errs,
+      throw new Error("Invalid `config.json`.", {
+        cause: errs,
       });
-      throw er;
     }
 
     if(DEVELOPMENT_PHASE && (!config || typeof config !== "object" || !("debug" in config) || !config.debug)){


### PR DESCRIPTION
* Better handling of fatal errors
* Don't reconnect when an error occurred because not all errors does need reconnecting.
  * This has been caused a fatal error 'WebSocket was closed before the connection was established'