### PR TITLE
Fix: skip failing strategy when retrying

### DIFF
--- a/src/AudioSource/spotify.ts
+++ b/src/AudioSource/spotify.ts
@@ -87,7 +87,7 @@ export class Spotify extends AudioSource<string, SpotifyJsonFormat> {
     assertIsNotNull(this.referenceUrl);
 
     // fetch the video
-    const { result } = await attemptFetchForStrategies(this.referenceUrl, forceUrl);
+    const { result } = await attemptFetchForStrategies([this.referenceUrl, forceUrl]);
 
     this.title = result.info.title;
     this.lengthSeconds = result.info.length;

--- a/src/AudioSource/youtube/strategies/distube_ytdl-core.ts
+++ b/src/AudioSource/youtube/strategies/distube_ytdl-core.ts
@@ -136,7 +136,10 @@ export class distubeYtdlCoreStrategy extends Strategy<distubeYtdlCoreCache, ytdl
             ? "webm/opus"
             : "unknown",
         } as UrlStreamInfo,
-        cache: null!,
+        cache: {
+          type: distubeYtdlCore,
+          data: info,
+        },
       };
     } else {
       const readable: Readable = info.videoDetails.liveBroadcastDetails && info.videoDetails.liveBroadcastDetails.isLiveNow
@@ -153,7 +156,10 @@ export class distubeYtdlCoreStrategy extends Strategy<distubeYtdlCoreCache, ytdl
               ? "webm/opus"
               : "unknown",
         } as ReadableStreamInfo,
-        cache: null!,
+        cache: {
+          type: distubeYtdlCore,
+          data: info,
+        },
       };
     }
   }

--- a/src/Component/playManager.ts
+++ b/src/Component/playManager.ts
@@ -852,7 +852,8 @@ export class PlayManager extends ServerManagerBase<PlayManagerEvents> {
     this.emit("playFailed");
     this._cost = 0;
     this.destroyStream();
-    this.currentAudioInfo!.purgeCache();
+    // @ts-expect-error youtubeの場合の引数 いつか™型の整合性は治したい
+    this.currentAudioInfo!.purgeCache(this._errorCount >= 1);
 
     if (this._errorUrl === this.currentAudioInfo!.url && !quiet) {
       this._errorCount++;


### PR DESCRIPTION
This PR changes the behavior when failing to play audio sources.
The current behavior is to retry playback 3 times. In every attempts, trying to use available strategies one by one.
After this PR landed, in 3rd attempt, the strategy that once causes some error will be skipped.
If the audio source cannot be played, we expect some error will be thrown in the step of calling AudioSource#fetch. However in fact, there are so many cases that calling AudioSource#fetch succeeds and some error occurs while reading the stream as the result of the method. Skipping strategies that return streams that is actually not playable makes the playback stablity better by using the good alternative strategies.

<!--

AIによるとこうしたいらしい

This PR modifies the behavior when an audio source fails to play.

Currently, when playback fails, the system retries three times, using available strategies in sequence. After this PR, on the third attempt, any strategy that previously caused an error will be skipped.

If the audio source cannot be played, we expect an error to be thrown when calling AudioSource#fetch. However, in many cases, AudioSource#fetch succeeds, but an error occurs while reading the stream. By skipping strategies that return streams that are not actually playable, playback stability will be improved by prioritizing alternative strategies that work.



あとで英語の勉強をしたいですね。

-->