### PR TITLE
Update: @distube/ytdl-core 4.16.6 to 4.16.8

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -10,7 +10,7 @@
       "license": "GPL-3.0-only",
       "dependencies": {
         "@discordjs/voice": "^0.17.0",
-        "@distube/ytdl-core": "^4.16.6",
+        "@distube/ytdl-core": "^4.16.8",
         "@mtripg6666tdr/async-lock": "^1.1.0",
         "@mtripg6666tdr/oceanic-command-resolver": "~1.4.2",
         "@sinclair/typebox": "^0.34.31",
@@ -222,9 +222,9 @@
       }
     },
     "node_modules/@distube/ytdl-core": {
-      "version": "4.16.6",
-      "resolved": "https://registry.npmjs.org/@distube/ytdl-core/-/ytdl-core-4.16.6.tgz",
-      "integrity": "sha512-+K88E2FRk/QPSC3l/U/qNq2LO0hPmFnDmK8CHK1Pzwh530aSacTLBhuZPgtoJAwNNncaTkmskP6lXoaw2eZjQw==",
+      "version": "4.16.8",
+      "resolved": "https://registry.npmjs.org/@distube/ytdl-core/-/ytdl-core-4.16.8.tgz",
+      "integrity": "sha512-Vl04TCOiSSwCFmOHVfzIX117tpT/eCobp2hwx4lo2EyeE70FMVrpQpKSEdh+EjywmVAHs/ZXIsaDy+wq1fMb+g==",
       "license": "MIT",
       "dependencies": {
         "http-cookie-agent": "^6.0.8",

--- a/package.json
+++ b/package.json
@@ -19,7 +19,7 @@
   },
   "dependencies": {
     "@discordjs/voice": "^0.17.0",
-    "@distube/ytdl-core": "^4.16.6",
+    "@distube/ytdl-core": "^4.16.8",
     "@mtripg6666tdr/async-lock": "^1.1.0",
     "@mtripg6666tdr/oceanic-command-resolver": "~1.4.2",
     "@sinclair/typebox": "^0.34.31",


### PR DESCRIPTION
既存の403エラーの解消が確認されました。

動作に問題は現状ありません。