### PR TITLE
Fix: Stream失敗後のリトライでoffsetストラテジーがスキップされる問題を修正

### DIFF
--- a/src/AudioSource/youtube/strategies/index.ts
+++ b/src/AudioSource/youtube/strategies/index.ts
@@ -127,21 +127,21 @@ export async function attemptFetchForStrategies<T extends Cache<string, U>, U>(p
     }
   }
   for (const i of generator()) {
-    if (i !== checkedStrategy && strategies[i] && strategies[i]?.module.cacheType !== attemptOffsetStrategyName) {
-      try {
-        const strategy = strategies[i]!;
-        const result = await strategy.module.fetch(...parameters);
-        return {
-          result,
-          resolved: i,
-          isFallbacked: strategy.isFallback,
-        };
-      } catch (e) {
-        logger.warn(`fetch in strategy#${i} failed`, e);
-      }
+    if (i === checkedStrategy || !strategies[i]) {
+      continue;
     }
-
-    logger.warn("Fallbacking to the next strategy");
+    try {
+      const strategy = strategies[i]!;
+      const result = await strategy.module.fetch(...parameters);
+      return {
+        result,
+        resolved: i,
+        isFallbacked: strategy.isFallback,
+      };
+    } catch (e) {
+      logger.warn(`fetch in strategy#${i} failed`, e);
+      logger.warn("Fallbacking to the next strategy");
+    }
   }
   throw new Error("All strategies failed");
 }


### PR DESCRIPTION
## 概要
Stream再生中にTLS接続が切断された場合、リトライ時に前回使用したストラテジーがスキップされ、劣等なフォールバックのみ試行される問題を修正。

## 修正内容
- メインループから cacheType !== attemptOffsetStrategyName 条件を削除
- Fallbacking to the next strategy ログを実際の失敗時のみ出力するように変更

## 変更ファイル
- src/AudioSource/youtube/strategies/index.ts