### PR TITLE
Update: DAVEプロトコル対応のための依存関係アップデート

### DIFF
--- a/package.json
+++ b/package.json
@@ -18,7 +18,7 @@
     "generatecommandlist": "node util/generateCommandList"
   },
   "dependencies": {
-    "@discordjs/voice": "^0.18.0",
+    "@discordjs/voice": "^0.19.0",
     "@distube/ytdl-core": "^4.16.12",
     "@mtripg6666tdr/async-lock": "^1.1.0",
     "@mtripg6666tdr/oceanic-command-resolver": "~1.5.3",
@@ -36,7 +36,7 @@
     "log4js": "^6.9.1",
     "miniget": "^4.2.3",
     "node-html-parser": "^7.0.1",
-    "oceanic.js": "~1.13.0",
+    "oceanic.js": "~1.14.0",
     "p-event": "^4.2.0",
     "p-queue": "^6.6.2",
     "prism-media": "^1.3.5",
@@ -94,7 +94,10 @@
     "zlib-sync": "^0.1.10"
   },
   "overrides": {
-    "whatwg-url": "13.0.0"
+    "whatwg-url": "13.0.0",
+    "@mtripg6666tdr/oceanic-command-resolver": {
+      "oceanic.js": "$oceanic.js"
+    }
   },
   "keywords": [],
   "author": "mtripg6666tdr",


### PR DESCRIPTION
## 概要
2026年3月2日よりDiscordのボイスチャンネルでDAVE (Discord Audio & Video End-to-End Encryption) プロトコルが必須化されたため、対応に必要な依存関係を更新しました。

## 変更内容
- @discordjs/voice ^0.18.0 → ^0.19.0（DAVEプロトコル対応）
- oceanic.js ~1.13.0 → ~1.14.0（@discordjs/voice ^0.19.0 に対応）
- overrides に @mtripg6666tdr/oceanic-command-resolver の oceanic.js バージョン指定を追加

## 破壊的変更
- **Node.js v22.12.0 以上が必須** になります
- @discordjs/voice v0.19.0 以降ではこれ未満のバージョンではボイスチャンネルへの接続ができません

## 変更ファイル
- package.json